### PR TITLE
feat(scaffold-mcp): extra prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ MCP server for scaffolding applications with boilerplate templates and feature g
 - 🔧 Built-in templates: Next.js 15, Vite + React
 - 🌐 Multiple transport modes: stdio, HTTP, SSE
 - 💻 Standalone CLI mode
+- 🎙️ Slash command prompts for AI coding agents
 
 [View full documentation →](./packages/scaffold-mcp/README.md)
 
@@ -166,6 +167,22 @@ Maximize effectiveness by combining three layers:
 3. **Hooks** → Intercept tool calls to enforce workflows (e.g., require scaffolding for new files)
 
 Experiment with these layers to find the right balance for your project. There's no one-size-fits-all solution.
+
+#### Slash Command Prompts
+
+The scaffold-mcp server provides built-in slash commands for AI coding agents like Claude Code:
+
+**For Users:**
+- **`/scaffold-mcp:scaffold-application`** - Guide the agent to create a new application from boilerplate templates
+- **`/scaffold-mcp:scaffold-feature`** - Guide the agent to add features (pages, components, services) to existing projects
+
+**For Template Creators:**
+- **`/scaffold-mcp:generate-boilerplate`** - Guide the agent to create a new boilerplate template configuration
+- **`/scaffold-mcp:generate-feature-scaffold`** - Guide the agent to create a new feature scaffold configuration
+
+These prompts provide step-by-step instructions to the AI agent, ensuring it follows the correct workflow for scaffolding tasks. They're automatically available when the MCP server is configured in your coding agent.
+
+📖 **[Learn how to use prompts →](./packages/scaffold-mcp/docs/how-to.md)**
 
 ---
 
@@ -229,6 +246,7 @@ pnpm release
 ## Documentation
 
 - **[Scaffold MCP Guide](./packages/scaffold-mcp/README.md)** - Complete guide to the scaffolding MCP server
+- **[How to Use Prompts](./packages/scaffold-mcp/docs/how-to.md)** - Step-by-step guide for using slash command prompts
 - **[Contributing Guide](./CONTRIBUTING.md)** - How to contribute to this project
 - **[Publishing Guide](./PUBLISHING.md)** - Release and versioning workflow
 

--- a/packages/scaffold-mcp/docs/how-to.md
+++ b/packages/scaffold-mcp/docs/how-to.md
@@ -1,0 +1,323 @@
+# How to Use Scaffold MCP Prompts
+
+This guide shows you how to use the scaffold-mcp slash command prompts with AI coding agents like Claude Code.
+
+## Table of Contents
+
+- [For Users: Using Existing Templates](#for-users-using-existing-templates)
+  - [Creating a New Application](#creating-a-new-application)
+  - [Adding Features to Existing Projects](#adding-features-to-existing-projects)
+- [For Template Creators: Creating Custom Templates](#for-template-creators-creating-custom-templates)
+  - [Creating a Boilerplate Template](#creating-a-boilerplate-template)
+  - [Creating a Feature Scaffold](#creating-a-feature-scaffold)
+
+---
+
+## For Users: Using Existing Templates
+
+### Creating a New Application
+
+Use the `/scaffold-mcp:scaffold-application` prompt to create a new project from built-in templates.
+
+**Example prompts:**
+```
+/scaffold-mcp:scaffold-application create a new Next.js app for e-commerce
+/scaffold-mcp:scaffold-application I need a new React app with Vite
+/scaffold-mcp:scaffold-application scaffold a dashboard application
+```
+
+**What happens:**
+1. The AI agent will list available boilerplate templates
+2. It will ask for required information (project name, description, etc.)
+3. It will create your project in the appropriate directory
+4. You'll get instructions on how to run it
+
+**Tips:**
+- Use descriptive project names in kebab-case (e.g., `user-dashboard`, `admin-panel`)
+- The AI will infer the best template based on your request
+- All projects are created in the `apps/` directory by default
+
+---
+
+### Adding Features to Existing Projects
+
+Use the `/scaffold-mcp:scaffold-feature` prompt to add pages, components, or services to existing projects.
+
+**Example prompts:**
+```
+/scaffold-mcp:scaffold-feature add a products page to apps/ecommerce-app
+/scaffold-mcp:scaffold-feature create a dashboard route in my Next.js app
+/scaffold-mcp:scaffold-feature I need a new component in apps/my-app
+```
+
+**What happens:**
+1. The AI will check what scaffolding methods are available for your project
+2. It will ask for details about the feature (name, path, etc.)
+3. It will generate the files following your project's patterns
+4. You'll get guidance on how to use the generated code
+
+**Tips:**
+- Specify the project path (e.g., `apps/my-app`)
+- Available features depend on your project's template type
+- The AI follows your project's existing conventions automatically
+
+---
+
+## For Template Creators: Creating Custom Templates
+
+### Creating a Boilerplate Template
+
+Use the `/scaffold-mcp:generate-boilerplate` prompt to create a new boilerplate template from your codebase.
+
+**When to use:**
+- You have a project structure you want to reuse
+- You want to create templates for frameworks not yet supported
+- You need organization-specific boilerplates
+
+**Example prompts:**
+```
+/scaffold-mcp:generate-boilerplate create a template for Express API with TypeScript
+/scaffold-mcp:generate-boilerplate I want to make a boilerplate for React Native apps
+/scaffold-mcp:generate-boilerplate template for our internal microservice architecture
+```
+
+**What happens:**
+1. The AI will ask for template details:
+   - Framework/technology (e.g., "React Native", "Express")
+   - Template name in kebab-case (e.g., `react-native`)
+   - Boilerplate name prefixed with `scaffold-` (e.g., `scaffold-rn-app`)
+   - Target folder (`apps` or `packages`)
+   - Required variables (at minimum: `appName` or `packageName`)
+   - Files to include
+
+2. The AI will guide you through:
+   - Creating the boilerplate configuration with `generate-boilerplate`
+   - Creating template files with `generate-boilerplate-file`
+   - Testing the boilerplate with `use-boilerplate`
+
+**Step-by-step workflow:**
+
+#### Step 1: Provide Template Information
+The AI will ask for:
+- **Template name**: e.g., `express-api` (kebab-case)
+- **Boilerplate name**: e.g., `scaffold-express-api` (must start with `scaffold-`)
+- **Description**: Multi-paragraph overview explaining:
+  - Core technology stack and value proposition
+  - Target use cases
+  - Key integrations or features
+- **Target folder**: `apps` for applications, `packages` for libraries
+- **Variables**: At minimum `appName` or `packageName`
+
+#### Step 2: Generate Configuration
+The AI uses `generate-boilerplate` to create `templates/{template-name}/scaffold.yaml`
+
+#### Step 3: Create Template Files
+For each file in your template:
+- The AI uses `generate-boilerplate-file` to create `.liquid` files
+- Template files use `{{ variableName }}` for substitution
+- The AI adds helpful header comments with design patterns
+
+**Example template file:**
+```typescript
+// templates/express-api/src/index.ts.liquid
+/**
+ * {{ appName }} - Express API Server
+ *
+ * DESIGN PATTERNS:
+ * - MVC architecture with controller/service/repository layers
+ * - Dependency injection for testability
+ *
+ * CODING STANDARDS:
+ * - Use async/await for all async operations
+ * - Export types alongside implementations
+ */
+
+import express from 'express';
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.get('/', (req, res) => {
+  res.json({ message: 'Welcome to {{ appName }}' });
+});
+
+app.listen(PORT, () => {
+  console.log(`{{ appName }} running on port ${PORT}`);
+});
+```
+
+#### Step 4: Test Your Template
+The AI will:
+- List boilerplates to verify it appears
+- Test it by creating a sample project
+- Show you the generated files
+
+**Tips:**
+- Keep template content minimal and business-agnostic
+- Focus on structure and patterns, not specific business logic
+- Use clear variable names that make sense for your domain
+- Include comprehensive instructions for AI agents
+
+---
+
+### Creating a Feature Scaffold
+
+Use the `/scaffold-mcp:generate-feature-scaffold` prompt to create reusable feature generators.
+
+**When to use:**
+- You want to add scaffolding for pages, components, or services
+- You have coding patterns you want to standardize
+- You need to extend existing templates with new capabilities
+
+**Example prompts:**
+```
+/scaffold-mcp:generate-feature-scaffold create a page scaffold for Next.js
+/scaffold-mcp:generate-feature-scaffold I need a component generator for React
+/scaffold-mcp:generate-feature-scaffold scaffold for creating API routes in Express
+```
+
+**What happens:**
+1. The AI will ask for feature details:
+   - Template name (e.g., `nextjs-15`)
+   - Feature name prefixed with `scaffold-` (e.g., `scaffold-nextjs-component`)
+   - Feature type (page, component, service, etc.)
+   - Variables needed (e.g., `componentName`, `routePath`)
+   - Files to include (with optional conditions)
+
+2. The AI will guide you through:
+   - Creating the feature configuration with `generate-feature-scaffold`
+   - Creating template files with `generate-boilerplate-file`
+   - Testing the feature with `use-scaffold-method`
+
+**Step-by-step workflow:**
+
+#### Step 1: Provide Feature Information
+The AI will ask for:
+- **Template name**: e.g., `nextjs-15` (must already exist)
+- **Feature name**: e.g., `scaffold-nextjs-component` (must start with `scaffold-`)
+- **Description**: 2-3 sentences explaining:
+  - What type of code it generates
+  - Key features or capabilities
+  - When to use it
+- **Variables**: Required fields for generation (e.g., `componentName`, `path`)
+
+#### Step 2: Generate Configuration
+The AI uses `generate-feature-scaffold` to add the feature to `templates/{template-name}/scaffold.yaml`
+
+#### Step 3: Create Template Files
+For each file the feature generates:
+- The AI uses `generate-boilerplate-file` to create `.liquid` files
+- Supports conditional includes: `file.tsx?withTests=true`
+- Supports path mapping: `component.tsx->src/{{ componentPath }}/Component.tsx`
+
+**Example feature template:**
+```typescript
+// templates/nextjs-15/src/components/Component.tsx.liquid
+/**
+ * {{ componentName }} Component
+ *
+ * DESIGN PATTERNS:
+ * - Server Component by default (add 'use client' only when needed)
+ * - Props interface defined above component
+ *
+ * CODING STANDARDS:
+ * - Component name must be PascalCase
+ * - Export as default for Next.js compatibility
+ */
+
+interface {{ componentName }}Props {
+  // TODO: Add props
+}
+
+export default function {{ componentName }}({ }: {{ componentName }}Props) {
+  return (
+    <div>
+      <h1>{{ componentName }}</h1>
+    </div>
+  );
+}
+```
+
+#### Step 4: Test Your Feature
+The AI will:
+- List scaffolding methods to verify it appears
+- Test it in a sample project
+- Show you the generated files
+
+**Advanced: Conditional Includes**
+
+Use conditional syntax for optional files:
+
+```yaml
+includes:
+  - "src/components/{{ componentName }}.tsx"
+  - "src/components/{{ componentName }}.test.tsx?withTests=true"
+  - "src/components/{{ componentName }}.stories.tsx?withStories=true"
+```
+
+**Advanced: Path Mapping**
+
+Map source templates to dynamic target paths:
+
+```yaml
+includes:
+  - "component.tsx->src/{{ componentPath }}/{{ componentName }}.tsx"
+  - "index.ts->src/{{ componentPath }}/index.ts"
+```
+
+**Tips:**
+- Keep generated code minimal - let AI fill in business logic later
+- Add clear header comments explaining patterns and standards
+- Use conditional includes for optional features (tests, stories, etc.)
+- Test your feature scaffold thoroughly before sharing
+
+---
+
+## Best Practices
+
+### For All Users
+
+1. **Use Clear Prompts**: Be specific about what you want
+2. **Follow Naming Conventions**: Use kebab-case for project/template names
+3. **Leverage AI Guidance**: The prompts provide step-by-step instructions
+4. **Test Thoroughly**: Always test generated code before committing
+
+### For Template Creators
+
+1. **Keep Templates Generic**: Focus on structure, not business logic
+2. **Document Patterns**: Use header comments to explain design decisions
+3. **Provide Clear Instructions**: Help AI understand your conventions
+4. **Use Variables Wisely**: Make templates flexible but not overcomplicated
+5. **Test with Real Projects**: Create sample projects to validate templates
+
+---
+
+## Troubleshooting
+
+### Template Not Found
+- Make sure you're using the correct template name
+- Run `list-boilerplates` or `list-scaffolding-methods` to see available options
+
+### Variables Not Working
+- Check that variable names match exactly (case-sensitive)
+- Ensure all required variables are provided
+- Use `{{ variableName }}` syntax in template files
+
+### Files Not Generated
+- Verify file paths in the `includes` array
+- Check conditional syntax for optional files (`?condition=true`)
+- Ensure template files have `.liquid` extension
+
+### Getting Help
+- Check the [scaffold-mcp README](../README.md) for detailed documentation
+- Review example templates in the `templates/` directory
+- Open an issue on GitHub if you need assistance
+
+---
+
+## Next Steps
+
+- **Explore Examples**: Check `templates/nextjs-15/` for a complete example
+- **Read the API Docs**: See [README.md](../README.md) for MCP tool documentation
+- **Join the Community**: Share your templates and get help from others
+- **Contribute**: Help improve scaffold-mcp by contributing templates or features

--- a/packages/scaffold-mcp/src/prompts/ScaffoldApplicationPrompt.ts
+++ b/packages/scaffold-mcp/src/prompts/ScaffoldApplicationPrompt.ts
@@ -1,0 +1,97 @@
+import type { PromptDefinition, PromptMessage } from './types';
+
+/**
+ * Prompt for scaffolding a new application using boilerplate templates
+ */
+export class ScaffoldApplicationPrompt {
+  static readonly PROMPT_NAME = 'scaffold-application';
+
+  /**
+   * Get the prompt definition for MCP
+   */
+  getDefinition(): PromptDefinition {
+    return {
+      name: ScaffoldApplicationPrompt.PROMPT_NAME,
+      description: 'Scaffold a new application from a boilerplate template',
+      arguments: [
+        {
+          name: 'request',
+          description: 'Describe the application you want to create (optional)',
+          required: false,
+        },
+      ],
+    };
+  }
+
+  /**
+   * Get the prompt messages
+   */
+  getMessages(args?: { request?: string }): PromptMessage[] {
+    const userRequest = args?.request || '';
+
+    return [
+      {
+        role: 'user',
+        content: {
+          type: 'text',
+          text: `You are helping create a new application using the scaffold-mcp MCP tools.
+
+${userRequest ? `User request: ${userRequest}\n` : ''}
+Your task is to scaffold a new application by following this workflow:
+
+## Step 1: List Available Boilerplates
+Use the \`list-boilerplates\` tool to see all available project templates.
+
+**What to look for:**
+- Boilerplate name (e.g., "scaffold-nextjs-app", "scaffold-vite-app")
+- Description of what the boilerplate creates
+- Target folder where projects will be created (e.g., "apps", "packages")
+- Required and optional variables in the variables_schema
+
+## Step 2: Gather Required Information
+Based on the selected boilerplate's variables_schema, collect:
+- **Project name**: Must be kebab-case (e.g., "my-new-app", not "MyNewApp")
+- **Required variables**: All variables marked as required: true
+- **Optional variables**: Variables with required: false (ask user if needed)
+
+Common variables:
+- \`appName\` or \`packageName\`: The project name (kebab-case)
+- \`description\`: Brief description of what the project does
+- \`author\`: Author name
+
+## Step 3: Execute the Boilerplate
+Use the \`use-boilerplate\` tool with:
+- \`boilerplateName\`: Exact name from list-boilerplates response
+- \`variables\`: Object matching the variables_schema exactly
+
+**Example:**
+\`\`\`json
+{
+  "boilerplateName": "scaffold-nextjs-app",
+  "variables": {
+    "appName": "my-dashboard",
+    "description": "Admin dashboard for managing users",
+    "author": "John Doe"
+  }
+}
+\`\`\`
+
+## Important Guidelines:
+- **Always call \`list-boilerplates\` first** to see available options and their schemas
+- **Use exact variable names** from the schema (case-sensitive)
+- **Provide all required variables** - the tool will fail if any are missing
+- **Use kebab-case for project names** (e.g., "user-dashboard", not "UserDashboard")
+- The tool will create the project in the appropriate directory automatically
+- After creation, inform the user where the project was created
+
+## Example Workflow:
+1. Call \`list-boilerplates\` → See available templates
+2. Ask user which template to use (or infer from request)
+3. Collect required variables based on schema
+4. Call \`use-boilerplate\` with boilerplateName and variables
+5. Report success and next steps to the user`,
+        },
+      },
+    ];
+  }
+}

--- a/packages/scaffold-mcp/src/prompts/ScaffoldFeaturePrompt.ts
+++ b/packages/scaffold-mcp/src/prompts/ScaffoldFeaturePrompt.ts
@@ -1,0 +1,123 @@
+import type { PromptDefinition, PromptMessage } from './types';
+
+/**
+ * Prompt for scaffolding a new feature in an existing project
+ */
+export class ScaffoldFeaturePrompt {
+  static readonly PROMPT_NAME = 'scaffold-feature';
+
+  /**
+   * Get the prompt definition for MCP
+   */
+  getDefinition(): PromptDefinition {
+    return {
+      name: ScaffoldFeaturePrompt.PROMPT_NAME,
+      description: 'Scaffold a new feature (page, component, service, etc.) in an existing project',
+      arguments: [
+        {
+          name: 'request',
+          description: 'Describe the feature you want to add (optional)',
+          required: false,
+        },
+        {
+          name: 'projectPath',
+          description: 'Path to the project (e.g., "apps/my-app") - optional if can be inferred',
+          required: false,
+        },
+      ],
+    };
+  }
+
+  /**
+   * Get the prompt messages
+   */
+  getMessages(args?: { request?: string; projectPath?: string }): PromptMessage[] {
+    const userRequest = args?.request || '';
+    const projectPath = args?.projectPath || '';
+
+    return [
+      {
+        role: 'user',
+        content: {
+          type: 'text',
+          text: `You are helping add a new feature to an existing project using the scaffold-mcp MCP tools.
+
+${userRequest ? `User request: ${userRequest}\n` : ''}${projectPath ? `Project path: ${projectPath}\n` : ''}
+Your task is to scaffold a new feature by following this workflow:
+
+## Step 1: Identify the Project
+Determine the project path where the feature will be added:
+- If projectPath is provided, use it
+- Otherwise, ask the user or infer from context (e.g., "apps/my-app", "packages/my-lib")
+- The path should point to a directory containing a \`project.json\` file
+
+## Step 2: List Available Scaffolding Methods
+Use the \`list-scaffolding-methods\` tool with the projectPath.
+
+**What to look for:**
+- Feature name (e.g., "scaffold-nextjs-page", "scaffold-react-component")
+- Description of what files/code it generates
+- Required and optional variables in the variables_schema
+- The template type (derived from project's sourceTemplate)
+
+**Example:**
+\`\`\`json
+{
+  "projectPath": "apps/my-dashboard"
+}
+\`\`\`
+
+## Step 3: Gather Required Information
+Based on the selected scaffolding method's variables_schema, collect:
+- **Feature-specific variables**: Name, path, type, etc.
+- **Required variables**: All variables marked as required: true
+- **Optional variables**: Variables with required: false (ask user if needed)
+
+Common variables:
+- \`componentName\` / \`pageName\` / \`serviceName\`: Name in PascalCase
+- \`componentPath\` / \`pagePath\`: Where to place the file (may use kebab-case)
+- Boolean flags: \`withTests\`, \`withLayout\`, \`withStyles\`, etc.
+
+## Step 4: Execute the Scaffolding Method
+Use the \`use-scaffold-method\` tool with:
+- \`projectPath\`: Same path from step 1
+- \`scaffold_feature_name\`: Exact name from list-scaffolding-methods response
+- \`variables\`: Object matching the variables_schema exactly
+
+**Example:**
+\`\`\`json
+{
+  "projectPath": "apps/my-dashboard",
+  "scaffold_feature_name": "scaffold-nextjs-page",
+  "variables": {
+    "pageName": "UserProfile",
+    "pagePath": "user/profile",
+    "withLayout": true,
+    "withTests": false
+  }
+}
+\`\`\`
+
+## Important Guidelines:
+- **Always call \`list-scaffolding-methods\` first** with the projectPath
+- **Use exact variable names** from the schema (case-sensitive)
+- **Provide all required variables** - the tool will fail if any are missing
+- **Follow naming conventions**:
+  - Component/Page/Service names: PascalCase (e.g., "UserProfile")
+  - File paths: kebab-case or as specified in schema (e.g., "user/profile")
+- **Conditional files**: Files with \`?condition=true\` are only included when the variable is true
+- The tool will create files in the appropriate locations automatically
+- After creation, inform the user what files were created
+
+## Example Workflow:
+1. Identify project path (provided or ask user)
+2. Call \`list-scaffolding-methods\` → See available features for this project
+3. Ask user which feature to add (or infer from request)
+4. Collect required variables based on schema
+5. Call \`use-scaffold-method\` with projectPath, scaffold_feature_name, and variables
+6. Report success and list created files`,
+        },
+      },
+    ];
+  }
+}

--- a/packages/scaffold-mcp/src/prompts/index.ts
+++ b/packages/scaffold-mcp/src/prompts/index.ts
@@ -1,3 +1,5 @@
 export * from './GenerateBoilerplatePrompt';
 export * from './GenerateFeatureScaffoldPrompt';
+export * from './ScaffoldApplicationPrompt';
+export * from './ScaffoldFeaturePrompt';
 export * from './types';

--- a/packages/scaffold-mcp/tests/__mocks__/fs-extra.ts
+++ b/packages/scaffold-mcp/tests/__mocks__/fs-extra.ts
@@ -1,0 +1,116 @@
+import { vi } from 'vitest';
+
+// Virtual file system state
+let virtualFS: Map<string, { content: string; isDirectory: boolean }> = new Map();
+
+// Reset virtual file system
+export const __resetVirtualFS = () => {
+  virtualFS = new Map();
+};
+
+// Set virtual file or directory
+export const __setVirtualFile = (path: string, content: string, isDirectory = false) => {
+  virtualFS.set(path, { content, isDirectory });
+};
+
+// Mock implementations
+export const pathExists = vi.fn(async (path: string) => {
+  return virtualFS.has(path);
+});
+
+export const pathExistsSync = vi.fn((path: string) => {
+  return virtualFS.has(path);
+});
+
+export const readFile = vi.fn(async (path: string, encoding?: BufferEncoding) => {
+  const file = virtualFS.get(path);
+  if (!file || file.isDirectory) {
+    throw new Error(`ENOENT: no such file, open '${path}'`);
+  }
+  return file.content;
+});
+
+export const readFileSync = vi.fn((path: string, encoding?: BufferEncoding) => {
+  const file = virtualFS.get(path);
+  if (!file || file.isDirectory) {
+    throw new Error(`ENOENT: no such file, open '${path}'`);
+  }
+  return file.content;
+});
+
+export const writeFile = vi.fn(async (path: string, content: string, encoding?: BufferEncoding) => {
+  virtualFS.set(path, { content, isDirectory: false });
+});
+
+export const ensureDir = vi.fn(async (path: string) => {
+  virtualFS.set(path, { content: '', isDirectory: true });
+});
+
+export const copy = vi.fn(async (src: string, dest: string) => {
+  const file = virtualFS.get(src);
+  if (!file) {
+    throw new Error(`ENOENT: no such file or directory, copy '${src}' -> '${dest}'`);
+  }
+  virtualFS.set(dest, { ...file });
+});
+
+export const readdir = vi.fn(async (path: string) => {
+  const dir = virtualFS.get(path);
+  if (!dir || !dir.isDirectory) {
+    throw new Error(`ENOTDIR: not a directory, scandir '${path}'`);
+  }
+
+  // Return files/dirs that are children of this path
+  const children: string[] = [];
+  const pathPrefix = path.endsWith('/') ? path : `${path}/`;
+
+  for (const [filePath] of virtualFS) {
+    if (filePath.startsWith(pathPrefix)) {
+      const relativePath = filePath.substring(pathPrefix.length);
+      const parts = relativePath.split('/');
+      if (parts.length > 0 && parts[0] && !children.includes(parts[0])) {
+        children.push(parts[0]);
+      }
+    }
+  }
+
+  return children;
+});
+
+export const stat = vi.fn(async (path: string) => {
+  const file = virtualFS.get(path);
+  if (!file) {
+    throw new Error(`ENOENT: no such file or directory, stat '${path}'`);
+  }
+
+  return {
+    isDirectory: () => file.isDirectory,
+    isFile: () => !file.isDirectory,
+  };
+});
+
+export const readJson = vi.fn(async (path: string) => {
+  const file = virtualFS.get(path);
+  if (!file || file.isDirectory) {
+    throw new Error(`ENOENT: no such file, open '${path}'`);
+  }
+  return JSON.parse(file.content);
+});
+
+export const remove = vi.fn(async (path: string) => {
+  virtualFS.delete(path);
+});
+
+export default {
+  pathExists,
+  pathExistsSync,
+  readFile,
+  readFileSync,
+  writeFile,
+  ensureDir,
+  copy,
+  readdir,
+  stat,
+  readJson,
+  remove,
+};

--- a/packages/scaffold-mcp/tests/prompts/ScaffoldApplicationPrompt.test.ts
+++ b/packages/scaffold-mcp/tests/prompts/ScaffoldApplicationPrompt.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { ScaffoldApplicationPrompt } from '../../src/prompts/ScaffoldApplicationPrompt';
+
+describe('ScaffoldApplicationPrompt', () => {
+  let prompt: ScaffoldApplicationPrompt;
+
+  beforeEach(() => {
+    prompt = new ScaffoldApplicationPrompt();
+  });
+
+  describe('getDefinition', () => {
+    it('should return prompt definition', () => {
+      const definition = prompt.getDefinition();
+
+      expect(definition.name).toBe('scaffold-application');
+      expect(definition.description).toBeTruthy();
+      expect(definition.arguments).toBeDefined();
+    });
+
+    it('should have optional request argument', () => {
+      const definition = prompt.getDefinition();
+
+      expect(definition.arguments).toHaveLength(1);
+      expect(definition.arguments?.[0].name).toBe('request');
+      expect(definition.arguments?.[0].required).toBe(false);
+    });
+  });
+
+  describe('getMessages', () => {
+    it('should return messages array', () => {
+      const messages = prompt.getMessages();
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0].role).toBe('user');
+      expect(messages[0].content.type).toBe('text');
+    });
+
+    it('should include user request when provided', () => {
+      const messages = prompt.getMessages({ request: 'Create a Next.js dashboard app' });
+
+      expect(messages[0].content.text).toContain('Create a Next.js dashboard app');
+    });
+
+    it('should work without user request', () => {
+      const messages = prompt.getMessages();
+
+      expect(messages[0].content.text).toBeTruthy();
+    });
+
+    it('should include workflow instructions', () => {
+      const messages = prompt.getMessages();
+
+      expect(messages[0].content.text).toContain('list-boilerplates');
+      expect(messages[0].content.text).toContain('use-boilerplate');
+    });
+
+    it('should include guidelines for variables', () => {
+      const messages = prompt.getMessages();
+
+      expect(messages[0].content.text).toContain('variables_schema');
+      expect(messages[0].content.text).toContain('kebab-case');
+    });
+
+    it('should include example workflow', () => {
+      const messages = prompt.getMessages();
+
+      expect(messages[0].content.text).toContain('Example');
+      expect(messages[0].content.text).toContain('boilerplateName');
+    });
+  });
+});

--- a/packages/scaffold-mcp/tests/prompts/ScaffoldFeaturePrompt.test.ts
+++ b/packages/scaffold-mcp/tests/prompts/ScaffoldFeaturePrompt.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { ScaffoldFeaturePrompt } from '../../src/prompts/ScaffoldFeaturePrompt';
+
+describe('ScaffoldFeaturePrompt', () => {
+  let prompt: ScaffoldFeaturePrompt;
+
+  beforeEach(() => {
+    prompt = new ScaffoldFeaturePrompt();
+  });
+
+  describe('getDefinition', () => {
+    it('should return prompt definition', () => {
+      const definition = prompt.getDefinition();
+
+      expect(definition.name).toBe('scaffold-feature');
+      expect(definition.description).toBeTruthy();
+      expect(definition.arguments).toBeDefined();
+    });
+
+    it('should have optional request and projectPath arguments', () => {
+      const definition = prompt.getDefinition();
+
+      expect(definition.arguments).toHaveLength(2);
+      expect(definition.arguments?.[0].name).toBe('request');
+      expect(definition.arguments?.[0].required).toBe(false);
+      expect(definition.arguments?.[1].name).toBe('projectPath');
+      expect(definition.arguments?.[1].required).toBe(false);
+    });
+  });
+
+  describe('getMessages', () => {
+    it('should return messages array', () => {
+      const messages = prompt.getMessages();
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0].role).toBe('user');
+      expect(messages[0].content.type).toBe('text');
+    });
+
+    it('should include user request when provided', () => {
+      const messages = prompt.getMessages({ request: 'Add a user profile page' });
+
+      expect(messages[0].content.text).toContain('Add a user profile page');
+    });
+
+    it('should include project path when provided', () => {
+      const messages = prompt.getMessages({ projectPath: 'apps/my-app' });
+
+      expect(messages[0].content.text).toContain('apps/my-app');
+    });
+
+    it('should work without arguments', () => {
+      const messages = prompt.getMessages();
+
+      expect(messages[0].content.text).toBeTruthy();
+    });
+
+    it('should include workflow instructions', () => {
+      const messages = prompt.getMessages();
+
+      expect(messages[0].content.text).toContain('list-scaffolding-methods');
+      expect(messages[0].content.text).toContain('use-scaffold-method');
+    });
+
+    it('should include guidelines for variables', () => {
+      const messages = prompt.getMessages();
+
+      expect(messages[0].content.text).toContain('variables_schema');
+      expect(messages[0].content.text).toContain('PascalCase');
+    });
+
+    it('should mention conditional files', () => {
+      const messages = prompt.getMessages();
+
+      expect(messages[0].content.text).toContain('?condition=true');
+    });
+
+    it('should include example workflow', () => {
+      const messages = prompt.getMessages();
+
+      expect(messages[0].content.text).toContain('Example');
+      expect(messages[0].content.text).toContain('scaffold_feature_name');
+    });
+  });
+});

--- a/packages/scaffold-mcp/tests/services/FileSystemService.test.ts
+++ b/packages/scaffold-mcp/tests/services/FileSystemService.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs-extra';
+import { FileSystemService } from '../../src/services/FileSystemService';
+
+// Mock fs-extra
+vi.mock('fs-extra');
+
+describe('FileSystemService', () => {
+  let service: FileSystemService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new FileSystemService();
+  });
+
+  describe('pathExists', () => {
+    it('should check if path exists', async () => {
+      await service.pathExists('/test/path');
+
+      expect(fs.pathExists).toHaveBeenCalledWith('/test/path');
+    });
+
+    it('should call pathExists for non-existent path', async () => {
+      await service.pathExists('/non/existent');
+
+      expect(fs.pathExists).toHaveBeenCalledWith('/non/existent');
+    });
+  });
+
+  describe('readFile', () => {
+    it('should read file with default encoding', async () => {
+      await service.readFile('/test/file.txt');
+
+      expect(fs.readFile).toHaveBeenCalledWith('/test/file.txt', 'utf8');
+    });
+
+    it('should read file with custom encoding', async () => {
+      await service.readFile('/test/file.txt', 'ascii');
+
+      expect(fs.readFile).toHaveBeenCalledWith('/test/file.txt', 'ascii');
+    });
+  });
+
+  describe('readJson', () => {
+    it('should read and parse JSON file', async () => {
+      const jsonData = { key: 'value' };
+      const mockFn = fs.readJson as any;
+      if (mockFn?.mockResolvedValue) {
+        mockFn.mockResolvedValue(jsonData);
+      }
+
+      const result = await service.readJson('/test/file.json');
+
+      if (result) {
+        expect(result).toEqual(jsonData);
+      }
+      expect(fs.readJson).toHaveBeenCalledWith('/test/file.json');
+    });
+  });
+
+  describe('writeFile', () => {
+    it('should write file with default encoding', async () => {
+      const mockFn = fs.writeFile as any;
+      if (mockFn?.mockResolvedValue) {
+        mockFn.mockResolvedValue(undefined);
+      }
+
+      await service.writeFile('/test/file.txt', 'content');
+
+      expect(fs.writeFile).toHaveBeenCalledWith('/test/file.txt', 'content', 'utf8');
+    });
+
+    it('should write file with custom encoding', async () => {
+      const mockFn = fs.writeFile as any;
+      if (mockFn?.mockResolvedValue) {
+        mockFn.mockResolvedValue(undefined);
+      }
+
+      await service.writeFile('/test/file.txt', 'content', 'ascii');
+
+      expect(fs.writeFile).toHaveBeenCalledWith('/test/file.txt', 'content', 'ascii');
+    });
+  });
+
+  describe('ensureDir', () => {
+    it('should ensure directory exists', async () => {
+      const mockFn = fs.ensureDir as any;
+      if (mockFn?.mockResolvedValue) {
+        mockFn.mockResolvedValue(undefined);
+      }
+
+      await service.ensureDir('/test/dir');
+
+      expect(fs.ensureDir).toHaveBeenCalledWith('/test/dir');
+    });
+  });
+
+  describe('copy', () => {
+    it('should copy files or directories', async () => {
+      const mockFn = fs.copy as any;
+      if (mockFn?.mockResolvedValue) {
+        mockFn.mockResolvedValue(undefined);
+      }
+
+      await service.copy('/src/path', '/dest/path');
+
+      expect(fs.copy).toHaveBeenCalledWith('/src/path', '/dest/path');
+    });
+  });
+
+  describe('readdir', () => {
+    it('should read directory contents', async () => {
+      const files = ['file1.txt', 'file2.txt'];
+      const mockFn = fs.readdir as any;
+      if (mockFn?.mockResolvedValue) {
+        mockFn.mockResolvedValue(files);
+      }
+
+      const result = await service.readdir('/test/dir');
+
+      if (result) {
+        expect(result).toEqual(files);
+      }
+      expect(fs.readdir).toHaveBeenCalledWith('/test/dir');
+    });
+  });
+
+  describe('stat', () => {
+    it('should get file stats', async () => {
+      const stats = {
+        isDirectory: () => false,
+        isFile: () => true,
+      };
+      const statMock = fs.stat as any;
+      if (statMock.mockResolvedValue) {
+        statMock.mockResolvedValue(stats);
+      }
+
+      const result = await service.stat('/test/file.txt');
+
+      if (result) {
+        expect(result.isFile()).toBe(true);
+        expect(result.isDirectory()).toBe(false);
+      }
+      expect(fs.stat).toHaveBeenCalledWith('/test/file.txt');
+    });
+
+    it('should identify directories', async () => {
+      const stats = {
+        isDirectory: () => true,
+        isFile: () => false,
+      };
+      const statMock = fs.stat as any;
+      if (statMock.mockResolvedValue) {
+        statMock.mockResolvedValue(stats);
+      }
+
+      const result = await service.stat('/test/dir');
+
+      if (result) {
+        expect(result.isDirectory()).toBe(true);
+        expect(result.isFile()).toBe(false);
+      }
+    });
+  });
+});

--- a/packages/scaffold-mcp/tests/services/TemplatesManager.test.ts
+++ b/packages/scaffold-mcp/tests/services/TemplatesManager.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Create virtual FS before importing anything
+const virtualFS = new Map<string, { content: string; isDirectory: boolean }>();
+
+const resetVirtualFS = () => {
+  virtualFS.clear();
+};
+
+const setVirtualFile = (path: string, content: string, isDirectory = false) => {
+  virtualFS.set(path, { content, isDirectory });
+};
+
+// Mock fs-extra with hoisted mock factory
+vi.mock('fs-extra', () => ({
+  default: {
+    pathExists: vi.fn(async (path: string) => virtualFS.has(path)),
+    pathExistsSync: vi.fn((path: string) => virtualFS.has(path)),
+    readFile: vi.fn(async (path: string) => {
+      const file = virtualFS.get(path);
+      if (!file || file.isDirectory) throw new Error(`ENOENT: no such file, open '${path}'`);
+      return file.content;
+    }),
+    readFileSync: vi.fn((path: string) => {
+      const file = virtualFS.get(path);
+      if (!file || file.isDirectory) throw new Error(`ENOENT: no such file, open '${path}'`);
+      return file.content;
+    }),
+    stat: vi.fn(async (path: string) => {
+      const file = virtualFS.get(path);
+      if (!file) throw new Error(`ENOENT: no such file or directory, stat '${path}'`);
+      return {
+        isDirectory: () => file.isDirectory,
+        isFile: () => !file.isDirectory,
+      };
+    }),
+  },
+  pathExists: vi.fn(async (path: string) => virtualFS.has(path)),
+  pathExistsSync: vi.fn((path: string) => virtualFS.has(path)),
+  readFile: vi.fn(async (path: string) => {
+    const file = virtualFS.get(path);
+    if (!file || file.isDirectory) throw new Error(`ENOENT: no such file, open '${path}'`);
+    return file.content;
+  }),
+  readFileSync: vi.fn((path: string) => {
+    const file = virtualFS.get(path);
+    if (!file || file.isDirectory) throw new Error(`ENOENT: no such file, open '${path}'`);
+    return file.content;
+  }),
+  stat: vi.fn(async (path: string) => {
+    const file = virtualFS.get(path);
+    if (!file) throw new Error(`ENOENT: no such file or directory, stat '${path}'`);
+    return {
+      isDirectory: () => file.isDirectory,
+      isFile: () => !file.isDirectory,
+    };
+  }),
+}));
+
+vi.mock('js-yaml', () => ({
+  load: vi.fn((content: string) => {
+    const match = content.match(/templatesPath:\s*(.+)/);
+    if (match) {
+      return { templatesPath: match[1].trim() };
+    }
+    return {};
+  }),
+}));
+
+import { TemplatesManager } from '../../src/services/TemplatesManager';
+
+describe('TemplatesManager', () => {
+  beforeEach(() => {
+    resetVirtualFS();
+    vi.clearAllMocks();
+  });
+
+  describe('findTemplatesPath', () => {
+    it('should find templates in workspace root when toolkit.yaml exists', async () => {
+      setVirtualFile('/test/workspace/.git', '', true);
+      setVirtualFile('/test/workspace/toolkit.yaml', 'templatesPath: custom-templates');
+      setVirtualFile('/test/workspace/custom-templates', '', true);
+
+      const result = await TemplatesManager.findTemplatesPath('/test/workspace/project');
+
+      expect(result).toContain('custom-templates');
+    });
+
+    it('should use default templates folder when toolkit.yaml does not exist', async () => {
+      setVirtualFile('/test/workspace/.git', '', true);
+      setVirtualFile('/test/workspace/templates', '', true);
+
+      const result = await TemplatesManager.findTemplatesPath('/test/workspace');
+
+      expect(result).toContain('templates');
+    });
+
+    it('should throw error when templates folder does not exist', async () => {
+      setVirtualFile('/test/workspace/.git', '', true);
+
+      await expect(TemplatesManager.findTemplatesPath('/test/workspace')).rejects.toThrow(
+        'Templates folder not found',
+      );
+    });
+
+    it('should handle absolute paths in toolkit.yaml', async () => {
+      setVirtualFile('/test/workspace/.git', '', true);
+      setVirtualFile('/test/workspace/toolkit.yaml', 'templatesPath: /absolute/templates');
+      setVirtualFile('/absolute/templates', '', true);
+
+      const result = await TemplatesManager.findTemplatesPath('/test/workspace');
+
+      expect(result).toBe('/absolute/templates');
+    });
+  });
+
+  describe('findTemplatesPathSync', () => {
+    it('should find templates synchronously', () => {
+      setVirtualFile('/test/workspace/.git', '', true);
+      setVirtualFile('/test/workspace/toolkit.yaml', 'templatesPath: custom-templates');
+      setVirtualFile('/test/workspace/custom-templates', '', true);
+
+      const result = TemplatesManager.findTemplatesPathSync('/test/workspace/project');
+
+      expect(result).toContain('custom-templates');
+    });
+
+    it('should use default templates folder when toolkit.yaml does not exist', () => {
+      setVirtualFile('/test/workspace/.git', '', true);
+      setVirtualFile('/test/workspace/templates', '', true);
+
+      const result = TemplatesManager.findTemplatesPathSync('/test/workspace');
+
+      expect(result).toContain('templates');
+    });
+  });
+
+  describe('isInitialized', () => {
+    it('should return true when templates directory exists', async () => {
+      setVirtualFile('/test/templates', '', true);
+
+      const result = await TemplatesManager.isInitialized('/test/templates');
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when templates path does not exist', async () => {
+      const result = await TemplatesManager.isInitialized('/test/templates');
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when path exists but is not a directory', async () => {
+      setVirtualFile('/test/templates', 'file content', false);
+
+      const result = await TemplatesManager.isInitialized('/test/templates');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('static getters', () => {
+    it('should return scaffold config file name', () => {
+      expect(TemplatesManager.getConfigFileName()).toBe('scaffold.yaml');
+    });
+
+    it('should return templates folder name', () => {
+      expect(TemplatesManager.getTemplatesFolderName()).toBe('templates');
+    });
+  });
+});

--- a/packages/scaffold-mcp/tests/services/VariableReplacementService.test.ts
+++ b/packages/scaffold-mcp/tests/services/VariableReplacementService.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { VariableReplacementService } from '../../src/services/VariableReplacementService';
+import type { IFileSystemService, ITemplateService } from '../../src/types/interfaces';
+
+describe('VariableReplacementService', () => {
+  let service: VariableReplacementService;
+  let mockFileSystem: IFileSystemService;
+  let mockTemplateService: ITemplateService;
+
+  beforeEach(() => {
+    mockFileSystem = {
+      readdir: vi.fn(),
+      stat: vi.fn(),
+      readFile: vi.fn(),
+      writeFile: vi.fn(),
+      pathExists: vi.fn(),
+      readJson: vi.fn(),
+      ensureDir: vi.fn(),
+      copy: vi.fn(),
+    };
+
+    mockTemplateService = {
+      renderString: vi.fn(),
+      renderFile: vi.fn(),
+    };
+
+    service = new VariableReplacementService(mockFileSystem, mockTemplateService);
+  });
+
+  describe('isBinaryFile', () => {
+    it('should identify binary files by extension', () => {
+      expect(service.isBinaryFile('image.png')).toBe(true);
+      expect(service.isBinaryFile('image.jpg')).toBe(true);
+      expect(service.isBinaryFile('font.woff2')).toBe(true);
+      expect(service.isBinaryFile('archive.zip')).toBe(true);
+      expect(service.isBinaryFile('doc.pdf')).toBe(true);
+    });
+
+    it('should not identify text files as binary', () => {
+      expect(service.isBinaryFile('file.txt')).toBe(false);
+      expect(service.isBinaryFile('file.js')).toBe(false);
+      expect(service.isBinaryFile('file.ts')).toBe(false);
+      expect(service.isBinaryFile('file.json')).toBe(false);
+      expect(service.isBinaryFile('file.md')).toBe(false);
+    });
+
+    it('should be case insensitive', () => {
+      expect(service.isBinaryFile('image.PNG')).toBe(true);
+      expect(service.isBinaryFile('image.JPG')).toBe(true);
+    });
+  });
+
+  describe('replaceVariablesInFile', () => {
+    it('should replace variables in text files', async () => {
+      const filePath = '/test/file.txt';
+      const variables = { name: 'John', age: 30 };
+      const content = 'Hello {{ name }}, you are {{ age }} years old';
+      const rendered = 'Hello John, you are 30 years old';
+
+      vi.mocked(mockFileSystem.readFile).mockResolvedValue(content);
+      vi.mocked(mockTemplateService.renderString).mockReturnValue(rendered);
+      vi.mocked(mockFileSystem.writeFile).mockResolvedValue();
+
+      await service.replaceVariablesInFile(filePath, variables);
+
+      expect(mockFileSystem.readFile).toHaveBeenCalledWith(filePath, 'utf8');
+      expect(mockTemplateService.renderString).toHaveBeenCalledWith(content, variables);
+      expect(mockFileSystem.writeFile).toHaveBeenCalledWith(filePath, rendered, 'utf8');
+    });
+
+    it('should skip binary files', async () => {
+      const filePath = '/test/image.png';
+      const variables = { name: 'test' };
+
+      await service.replaceVariablesInFile(filePath, variables);
+
+      expect(mockFileSystem.readFile).not.toHaveBeenCalled();
+      expect(mockTemplateService.renderString).not.toHaveBeenCalled();
+      expect(mockFileSystem.writeFile).not.toHaveBeenCalled();
+    });
+
+    it('should handle file read errors gracefully', async () => {
+      const filePath = '/test/file.txt';
+      const variables = { name: 'test' };
+
+      vi.mocked(mockFileSystem.readFile).mockRejectedValue(new Error('Permission denied'));
+
+      // Should not throw
+      await expect(service.replaceVariablesInFile(filePath, variables)).resolves.toBeUndefined();
+      expect(mockFileSystem.writeFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('processFilesForVariableReplacement', () => {
+    it('should process all files in directory recursively', async () => {
+      const dirPath = '/test/dir';
+      const variables = { name: 'test' };
+
+      vi.mocked(mockFileSystem.readdir).mockImplementation(async (path: string) => {
+        if (path === dirPath) return ['file1.txt', 'subdir'];
+        if (path === '/test/dir/subdir') return ['file2.txt'];
+        return [];
+      });
+
+      vi.mocked(mockFileSystem.stat).mockImplementation(async (path: string) => {
+        if (path.includes('subdir') && !path.includes('file2')) {
+          return { isDirectory: () => true, isFile: () => false } as any;
+        }
+        return { isDirectory: () => false, isFile: () => true } as any;
+      });
+
+      vi.mocked(mockFileSystem.readFile).mockResolvedValue('content {{ name }}');
+      vi.mocked(mockTemplateService.renderString).mockReturnValue('content test');
+      vi.mocked(mockFileSystem.writeFile).mockResolvedValue();
+
+      await service.processFilesForVariableReplacement(dirPath, variables);
+
+      expect(mockFileSystem.readdir).toHaveBeenCalledWith(dirPath);
+      expect(mockFileSystem.readdir).toHaveBeenCalledWith('/test/dir/subdir');
+      expect(mockFileSystem.writeFile).toHaveBeenCalledTimes(2);
+    });
+
+    it('should skip directories that cannot be read', async () => {
+      const dirPath = '/test/dir';
+      const variables = { name: 'test' };
+
+      vi.mocked(mockFileSystem.readdir).mockRejectedValue(new Error('Permission denied'));
+
+      // Should not throw
+      await expect(
+        service.processFilesForVariableReplacement(dirPath, variables),
+      ).resolves.toBeUndefined();
+      expect(mockFileSystem.stat).not.toHaveBeenCalled();
+    });
+
+    it('should skip items that cannot be stat-ed', async () => {
+      const dirPath = '/test/dir';
+      const variables = { name: 'test' };
+
+      vi.mocked(mockFileSystem.readdir).mockResolvedValue(['file1.txt']);
+      vi.mocked(mockFileSystem.stat).mockRejectedValue(new Error('Permission denied'));
+
+      // Should not throw
+      await expect(
+        service.processFilesForVariableReplacement(dirPath, variables),
+      ).resolves.toBeUndefined();
+      expect(mockFileSystem.readFile).not.toHaveBeenCalled();
+    });
+
+    it('should skip empty items', async () => {
+      const dirPath = '/test/dir';
+      const variables = { name: 'test' };
+
+      vi.mocked(mockFileSystem.readdir).mockResolvedValue(['', 'file.txt', null as any]);
+      vi.mocked(mockFileSystem.stat).mockResolvedValue({
+        isDirectory: () => false,
+        isFile: () => true,
+      } as any);
+      vi.mocked(mockFileSystem.readFile).mockResolvedValue('content');
+      vi.mocked(mockTemplateService.renderString).mockReturnValue('content');
+      vi.mocked(mockFileSystem.writeFile).mockResolvedValue();
+
+      await service.processFilesForVariableReplacement(dirPath, variables);
+
+      // Should only process file.txt, skipping empty and null items
+      expect(mockFileSystem.stat).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/scaffold-mcp/tests/setup.ts
+++ b/packages/scaffold-mcp/tests/setup.ts
@@ -1,14 +1,7 @@
 import { beforeEach, vi } from 'vitest';
 
-// Mock fs-extra
-vi.mock('fs-extra', () => ({
-  ensureDir: vi.fn(),
-  copy: vi.fn(),
-  writeFile: vi.fn(),
-  readFile: vi.fn(),
-  pathExists: vi.fn(),
-  remove: vi.fn(),
-}));
+// Note: fs-extra mock is in tests/__mocks__/fs-extra.ts
+// Vitest will automatically use it when vi.mock('fs-extra') is called
 
 // Mock @modelcontextprotocol/sdk
 vi.mock('@modelcontextprotocol/sdk/server/index.js', () => {

--- a/packages/scaffold-mcp/tests/tools/ListBoilerplatesTool.test.ts
+++ b/packages/scaffold-mcp/tests/tools/ListBoilerplatesTool.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ListBoilerplatesTool } from '../../src/tools/ListBoilerplatesTool';
+
+// Mock the service
+vi.mock('../../src/services/BoilerplateService');
+
+describe('ListBoilerplatesTool', () => {
+  let tool: ListBoilerplatesTool;
+  const templatesPath = '/test/templates';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tool = new ListBoilerplatesTool(templatesPath);
+  });
+
+  describe('getDefinition', () => {
+    it('should return tool definition with correct schema', () => {
+      const definition = tool.getDefinition();
+
+      expect(definition.name).toBe('list-boilerplates');
+      expect(definition.description).toBeTruthy();
+      expect(definition.description).toContain('Lists all available project boilerplates');
+      expect(definition.inputSchema.type).toBe('object');
+    });
+
+    it('should have no required properties', () => {
+      const definition = tool.getDefinition();
+
+      expect(definition.inputSchema.required).toBeUndefined();
+      expect(Object.keys(definition.inputSchema.properties || {})).toHaveLength(0);
+    });
+  });
+
+  describe('execute', () => {
+    it('should list boilerplates successfully', async () => {
+      const mockBoilerplates = {
+        boilerplates: [
+          {
+            name: 'scaffold-nextjs-app',
+            description: 'Next.js application template',
+            variables_schema: {
+              type: 'object',
+              properties: {
+                appName: { type: 'string', description: 'App name' },
+              },
+              required: ['appName'],
+            },
+            template_path: 'nextjs-15',
+            target_folder: 'apps',
+          },
+          {
+            name: 'scaffold-vite-app',
+            description: 'Vite application template',
+            variables_schema: {
+              type: 'object',
+              properties: {
+                appName: { type: 'string', description: 'App name' },
+              },
+              required: ['appName'],
+            },
+            template_path: 'vite-react',
+            target_folder: 'apps',
+          },
+        ],
+      };
+
+      const spy = vi.spyOn(tool['boilerplateService'], 'listBoilerplates');
+      spy.mockResolvedValue(mockBoilerplates);
+
+      const result = await tool.execute({});
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].type).toBe('text');
+
+      const response = JSON.parse(result.content[0].text);
+      expect(response.boilerplates).toHaveLength(2);
+      expect(response.boilerplates[0].name).toBe('scaffold-nextjs-app');
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('should handle empty boilerplates list', async () => {
+      const mockBoilerplates = {
+        boilerplates: [],
+      };
+
+      const spy = vi.spyOn(tool['boilerplateService'], 'listBoilerplates');
+      spy.mockResolvedValue(mockBoilerplates);
+
+      const result = await tool.execute();
+
+      expect(result.isError).toBeFalsy();
+      const response = JSON.parse(result.content[0].text);
+      expect(response.boilerplates).toHaveLength(0);
+    });
+
+    it('should handle service errors gracefully', async () => {
+      const spy = vi.spyOn(tool['boilerplateService'], 'listBoilerplates');
+      spy.mockRejectedValue(new Error('Failed to read templates directory'));
+
+      const result = await tool.execute();
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Failed to read templates directory');
+    });
+  });
+});

--- a/packages/scaffold-mcp/tests/tools/UseBoilerplateTool.test.ts
+++ b/packages/scaffold-mcp/tests/tools/UseBoilerplateTool.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { UseBoilerplateTool } from '../../src/tools/UseBoilerplateTool';
+
+// Mock the service
+vi.mock('../../src/services/BoilerplateService');
+
+describe('UseBoilerplateTool', () => {
+  let tool: UseBoilerplateTool;
+  const templatesPath = '/test/templates';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tool = new UseBoilerplateTool(templatesPath);
+  });
+
+  describe('getDefinition', () => {
+    it('should return tool definition with correct schema', () => {
+      const definition = tool.getDefinition();
+
+      expect(definition.name).toBe('use-boilerplate');
+      expect(definition.description).toBeTruthy();
+      expect(definition.inputSchema.type).toBe('object');
+      expect(definition.inputSchema.required).toContain('boilerplateName');
+      expect(definition.inputSchema.required).toContain('variables');
+    });
+
+    it('should include variables object in schema', () => {
+      const definition = tool.getDefinition();
+
+      expect(definition.inputSchema.properties.boilerplateName).toBeDefined();
+      expect(definition.inputSchema.properties.variables).toBeDefined();
+      expect(definition.inputSchema.properties.variables.type).toBe('object');
+    });
+  });
+
+  describe('execute', () => {
+    it('should execute successfully with valid arguments', async () => {
+      const args = {
+        boilerplateName: 'scaffold-nextjs-app',
+        variables: {
+          appName: 'my-app',
+          description: 'My test app',
+        },
+      };
+
+      const spy = vi.spyOn(tool['boilerplateService'], 'useBoilerplate');
+      spy.mockResolvedValue({
+        success: true,
+        message: 'Successfully scaffolded boilerplate at /path/to/project',
+        projectPath: '/path/to/project',
+      });
+
+      const result = await tool.execute(args);
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toContain('Successfully scaffolded');
+      expect(spy).toHaveBeenCalledWith({
+        boilerplateName: 'scaffold-nextjs-app',
+        variables: { appName: 'my-app', description: 'My test app' },
+      });
+    });
+
+    it('should return error when boilerplateName is missing', async () => {
+      const args = {
+        variables: { appName: 'test' },
+      };
+
+      const result = await tool.execute(args);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Missing required parameter: boilerplateName');
+    });
+
+    it('should return error when variables are missing', async () => {
+      const args = {
+        boilerplateName: 'scaffold-test-app',
+      };
+
+      const result = await tool.execute(args);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Missing required parameter: variables');
+    });
+
+    it('should handle service errors gracefully', async () => {
+      const args = {
+        boilerplateName: 'scaffold-test-app',
+        variables: { appName: 'test' },
+      };
+
+      const spy = vi.spyOn(tool['boilerplateService'], 'useBoilerplate');
+      spy.mockRejectedValue(new Error('Boilerplate not found'));
+
+      const result = await tool.execute(args);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Boilerplate not found');
+    });
+  });
+});

--- a/packages/scaffold-mcp/tests/tools/UseScaffoldMethodTool.test.ts
+++ b/packages/scaffold-mcp/tests/tools/UseScaffoldMethodTool.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { UseScaffoldMethodTool } from '../../src/tools/UseScaffoldMethodTool';
+
+// Mock the services
+vi.mock('../../src/services/FileSystemService');
+vi.mock('../../src/services/ScaffoldingMethodsService');
+
+describe('UseScaffoldMethodTool', () => {
+  let tool: UseScaffoldMethodTool;
+  const templatesPath = '/test/templates';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tool = new UseScaffoldMethodTool(templatesPath);
+  });
+
+  describe('getDefinition', () => {
+    it('should return tool definition with correct schema', () => {
+      const definition = tool.getDefinition();
+
+      expect(definition.name).toBe('use-scaffold-method');
+      expect(definition.description).toBeTruthy();
+      expect(definition.inputSchema.type).toBe('object');
+      expect(definition.inputSchema.required).toContain('projectPath');
+      expect(definition.inputSchema.required).toContain('scaffold_feature_name');
+      expect(definition.inputSchema.required).toContain('variables');
+    });
+
+    it('should include all required properties in schema', () => {
+      const definition = tool.getDefinition();
+
+      expect(definition.inputSchema.properties.projectPath).toBeDefined();
+      expect(definition.inputSchema.properties.scaffold_feature_name).toBeDefined();
+      expect(definition.inputSchema.properties.variables).toBeDefined();
+      expect(definition.inputSchema.properties.variables.type).toBe('object');
+    });
+  });
+
+  describe('execute', () => {
+    it('should execute successfully with valid arguments', async () => {
+      const args = {
+        projectPath: '/test/apps/my-app',
+        scaffold_feature_name: 'scaffold-route',
+        variables: {
+          routePath: 'about',
+          pageTitle: 'About Us',
+        },
+      };
+
+      const spy = vi.spyOn(tool['scaffoldingMethodsService'], 'useScaffoldMethod');
+      spy.mockResolvedValue({
+        success: true,
+        message: 'Successfully scaffolded scaffold-route in /test/apps/my-app',
+      });
+
+      const result = await tool.execute(args);
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toContain('Successfully scaffolded');
+      expect(spy).toHaveBeenCalledWith({
+        projectPath: '/test/apps/my-app',
+        scaffold_feature_name: 'scaffold-route',
+        variables: { routePath: 'about', pageTitle: 'About Us' },
+      });
+    });
+
+    it('should return error when projectPath is missing', async () => {
+      const args = {
+        scaffold_feature_name: 'scaffold-route',
+        variables: { routePath: 'about' },
+      };
+
+      const result = await tool.execute(args);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Missing required parameter: projectPath');
+    });
+
+    it('should return error when scaffold_feature_name is missing', async () => {
+      const args = {
+        projectPath: '/test/apps/my-app',
+        variables: { routePath: 'about' },
+      };
+
+      const result = await tool.execute(args);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Missing required parameter: scaffold_feature_name');
+    });
+
+    it('should return error when variables are missing', async () => {
+      const args = {
+        projectPath: '/test/apps/my-app',
+        scaffold_feature_name: 'scaffold-route',
+      };
+
+      const result = await tool.execute(args);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Missing required parameter: variables');
+    });
+
+    it('should handle service errors gracefully', async () => {
+      const args = {
+        projectPath: '/test/apps/my-app',
+        scaffold_feature_name: 'scaffold-route',
+        variables: { routePath: 'about' },
+      };
+
+      const spy = vi.spyOn(tool['scaffoldingMethodsService'], 'useScaffoldMethod');
+      spy.mockRejectedValue(new Error('Scaffold method not found'));
+
+      const result = await tool.execute(args);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Scaffold method not found');
+    });
+  });
+});

--- a/packages/scaffold-mcp/tests/tools/WriteToFileTool.test.ts
+++ b/packages/scaffold-mcp/tests/tools/WriteToFileTool.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WriteToFileTool } from '../../src/tools/WriteToFileTool';
+
+// Mock the service
+vi.mock('../../src/services/FileSystemService');
+
+describe('WriteToFileTool', () => {
+  let tool: WriteToFileTool;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tool = new WriteToFileTool();
+  });
+
+  describe('getDefinition', () => {
+    it('should return tool definition with correct schema', () => {
+      const definition = tool.getDefinition();
+
+      expect(definition.name).toBe('write-to-file');
+      expect(definition.description).toBeTruthy();
+      expect(definition.description).toContain('Writes content to a file');
+      expect(definition.inputSchema.type).toBe('object');
+      expect(definition.inputSchema.required).toContain('file_path');
+      expect(definition.inputSchema.required).toContain('content');
+    });
+
+    it('should include file_path and content in schema', () => {
+      const definition = tool.getDefinition();
+
+      expect(definition.inputSchema.properties.file_path).toBeDefined();
+      expect(definition.inputSchema.properties.file_path.type).toBe('string');
+      expect(definition.inputSchema.properties.content).toBeDefined();
+      expect(definition.inputSchema.properties.content.type).toBe('string');
+    });
+  });
+
+  describe('execute', () => {
+    it('should write file successfully with absolute path', async () => {
+      const args = {
+        file_path: '/test/output/file.txt',
+        content: 'Hello, World!',
+      };
+
+      const ensureDirSpy = vi.spyOn(tool['fileSystemService'], 'ensureDir');
+      const writeFileSpy = vi.spyOn(tool['fileSystemService'], 'writeFile');
+      ensureDirSpy.mockResolvedValue();
+      writeFileSpy.mockResolvedValue();
+
+      const result = await tool.execute(args);
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toContain('Successfully wrote content to file');
+      expect(result.content[0].text).toContain('/test/output/file.txt');
+      expect(ensureDirSpy).toHaveBeenCalledWith('/test/output');
+      expect(writeFileSpy).toHaveBeenCalledWith('/test/output/file.txt', 'Hello, World!');
+    });
+
+    it('should write file successfully with relative path', async () => {
+      const args = {
+        file_path: 'output/file.txt',
+        content: 'Test content',
+      };
+
+      const ensureDirSpy = vi.spyOn(tool['fileSystemService'], 'ensureDir');
+      const writeFileSpy = vi.spyOn(tool['fileSystemService'], 'writeFile');
+      ensureDirSpy.mockResolvedValue();
+      writeFileSpy.mockResolvedValue();
+
+      const result = await tool.execute(args);
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].text).toContain('Successfully wrote content to file');
+      expect(ensureDirSpy).toHaveBeenCalled();
+      expect(writeFileSpy).toHaveBeenCalled();
+    });
+
+    it('should handle empty content', async () => {
+      const args = {
+        file_path: '/test/empty.txt',
+        content: '',
+      };
+
+      const ensureDirSpy = vi.spyOn(tool['fileSystemService'], 'ensureDir');
+      const writeFileSpy = vi.spyOn(tool['fileSystemService'], 'writeFile');
+      ensureDirSpy.mockResolvedValue();
+      writeFileSpy.mockResolvedValue();
+
+      const result = await tool.execute(args);
+
+      expect(result.isError).toBeFalsy();
+      expect(writeFileSpy).toHaveBeenCalledWith('/test/empty.txt', '');
+    });
+
+    it('should return error when file_path is missing', async () => {
+      const args = {
+        content: 'Test content',
+      };
+
+      const result = await tool.execute(args);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Missing required parameter: file_path');
+    });
+
+    it('should return error when content is missing', async () => {
+      const args = {
+        file_path: '/test/file.txt',
+      };
+
+      const result = await tool.execute(args);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Missing required parameter: content');
+    });
+
+    it('should handle file system errors gracefully', async () => {
+      const args = {
+        file_path: '/test/file.txt',
+        content: 'Test',
+      };
+
+      const ensureDirSpy = vi.spyOn(tool['fileSystemService'], 'ensureDir');
+      ensureDirSpy.mockRejectedValue(new Error('Permission denied'));
+
+      const result = await tool.execute(args);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Permission denied');
+    });
+
+    it('should create parent directories before writing', async () => {
+      const args = {
+        file_path: '/deep/nested/path/file.txt',
+        content: 'content',
+      };
+
+      const ensureDirSpy = vi.spyOn(tool['fileSystemService'], 'ensureDir');
+      const writeFileSpy = vi.spyOn(tool['fileSystemService'], 'writeFile');
+      ensureDirSpy.mockResolvedValue();
+      writeFileSpy.mockResolvedValue();
+
+      await tool.execute(args);
+
+      expect(ensureDirSpy).toHaveBeenCalledWith('/deep/nested/path');
+      expect(writeFileSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/scaffold-mcp/tests/utils/console.test.ts
+++ b/packages/scaffold-mcp/tests/utils/console.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { logger, messages, sections, icons } from '../../src/utils/console';
+
+// Mock console methods
+const mockLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+const mockError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+describe('console utils', () => {
+  beforeEach(() => {
+    mockLog.mockClear();
+    mockError.mockClear();
+  });
+
+  describe('logger', () => {
+    it('should log info messages', () => {
+      logger.info('test message');
+
+      expect(mockLog).toHaveBeenCalledTimes(1);
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('test message'));
+    });
+
+    it('should log success messages', () => {
+      logger.success('success message');
+
+      expect(mockLog).toHaveBeenCalledTimes(1);
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('success message'));
+    });
+
+    it('should log warning messages', () => {
+      logger.warning('warning message');
+
+      expect(mockLog).toHaveBeenCalledTimes(1);
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('warning message'));
+    });
+
+    it('should log error messages', () => {
+      logger.error('error message');
+
+      expect(mockError).toHaveBeenCalledTimes(1);
+      expect(mockError).toHaveBeenCalledWith(expect.stringContaining('error message'));
+    });
+
+    it('should log error with Error object', () => {
+      const error = new Error('test error');
+      logger.error('error occurred', error);
+
+      expect(mockError).toHaveBeenCalledTimes(1);
+      expect(mockError).toHaveBeenCalledWith(
+        expect.stringContaining('error occurred'),
+        'test error',
+      );
+    });
+
+    it('should log error with error string', () => {
+      logger.error('error occurred', 'error details');
+
+      expect(mockError).toHaveBeenCalledTimes(1);
+      expect(mockError).toHaveBeenCalledWith(
+        expect.stringContaining('error occurred'),
+        'error details',
+      );
+    });
+
+    it('should log debug messages', () => {
+      logger.debug('debug message');
+
+      expect(mockLog).toHaveBeenCalledTimes(1);
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('debug message'));
+    });
+
+    it('should log header messages', () => {
+      logger.header('Header Title');
+
+      expect(mockLog).toHaveBeenCalledTimes(1);
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('Header Title'));
+    });
+
+    it('should log list items with prefix', () => {
+      logger.item('list item');
+
+      expect(mockLog).toHaveBeenCalledTimes(1);
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('- list item'));
+    });
+
+    it('should log indented text', () => {
+      logger.indent('indented text');
+
+      expect(mockLog).toHaveBeenCalledTimes(1);
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('indented text'));
+    });
+
+    it('should log highlighted text', () => {
+      logger.highlight('important text');
+
+      expect(mockLog).toHaveBeenCalledTimes(1);
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('important text'));
+    });
+
+    it('should log newlines', () => {
+      logger.newline();
+
+      expect(mockLog).toHaveBeenCalledTimes(1);
+      expect(mockLog).toHaveBeenCalledWith();
+    });
+  });
+
+  describe('icons', () => {
+    it('should have all required icons', () => {
+      expect(icons.check).toBeDefined();
+      expect(icons.cross).toBeDefined();
+      expect(icons.warning).toBeDefined();
+      expect(icons.info).toBeDefined();
+      expect(icons.rocket).toBeDefined();
+      expect(icons.folder).toBeDefined();
+      expect(icons.file).toBeDefined();
+      expect(icons.bulb).toBeDefined();
+    });
+  });
+
+  describe('messages', () => {
+    it('should display info message with icon', () => {
+      messages.info('info message');
+
+      expect(mockLog).toHaveBeenCalledTimes(1);
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('info message'));
+    });
+
+    it('should display success message with icon', () => {
+      messages.success('success message');
+
+      expect(mockLog).toHaveBeenCalledTimes(1);
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('success message'));
+    });
+
+    it('should display error message with icon', () => {
+      messages.error('error message');
+
+      expect(mockError).toHaveBeenCalledTimes(1);
+      expect(mockError).toHaveBeenCalledWith(expect.stringContaining('error message'));
+    });
+
+    it('should display warning message with icon', () => {
+      messages.warning('warning message');
+
+      expect(mockLog).toHaveBeenCalledTimes(1);
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('warning message'));
+    });
+
+    it('should display hint message with icon', () => {
+      messages.hint('helpful tip');
+
+      expect(mockLog).toHaveBeenCalledTimes(1);
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('helpful tip'));
+    });
+
+    it('should display loading message with icon', () => {
+      messages.loading('processing...');
+
+      expect(mockLog).toHaveBeenCalledTimes(1);
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('processing...'));
+    });
+  });
+
+  describe('sections', () => {
+    it('should print header section', () => {
+      sections.header('Section Title');
+
+      expect(mockLog).toHaveBeenCalled();
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('Section Title'));
+    });
+
+    it('should print list section with items', () => {
+      sections.list('My List', ['item 1', 'item 2', 'item 3']);
+
+      expect(mockLog).toHaveBeenCalled();
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('My List'));
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('item 1'));
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('item 2'));
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('item 3'));
+    });
+
+    it('should print next steps section', () => {
+      sections.nextSteps(['step 1', 'step 2']);
+
+      expect(mockLog).toHaveBeenCalled();
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('Next steps'));
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('step 1'));
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('step 2'));
+    });
+
+    it('should print created files section', () => {
+      sections.createdFiles(['file1.ts', 'file2.ts', 'file3.ts']);
+
+      expect(mockLog).toHaveBeenCalled();
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('Created files'));
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('file1.ts'));
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('file2.ts'));
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('file3.ts'));
+    });
+
+    it('should limit displayed files when exceeding max', () => {
+      const files = Array.from({ length: 15 }, (_, i) => `file${i + 1}.ts`);
+      sections.createdFiles(files, 5);
+
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('file1.ts'));
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('file5.ts'));
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('10 more files'));
+    });
+
+    it('should print warnings section', () => {
+      sections.warnings(['warning 1', 'warning 2']);
+
+      expect(mockLog).toHaveBeenCalled();
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('Warnings'));
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('warning 1'));
+      expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('warning 2'));
+    });
+  });
+});

--- a/packages/scaffold-mcp/tests/utils/file.test.ts
+++ b/packages/scaffold-mcp/tests/utils/file.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { getRootPath, getProjectPath } from '../../src/utils/file';
+
+// Mock import.meta.url
+vi.mock('node:url', () => ({
+  fileURLToPath: vi.fn(() => '/workspace/aicode-toolkit/packages/scaffold-mcp/dist/utils/file.js'),
+}));
+
+describe('file utils', () => {
+  describe('getRootPath', () => {
+    it('should return the root path of the project', () => {
+      const rootPath = getRootPath();
+
+      expect(rootPath).toBeTruthy();
+      expect(typeof rootPath).toBe('string');
+    });
+
+    it('should return a path that ends at the workspace root', () => {
+      const rootPath = getRootPath();
+
+      // The root path should go up 5 levels from dist/utils
+      expect(rootPath).toContain('workspace');
+    });
+  });
+
+  describe('getProjectPath', () => {
+    it('should remove root path from project path', () => {
+      const rootPath = getRootPath();
+      const fullPath = `${rootPath}/apps/my-app`;
+
+      const result = getProjectPath(fullPath);
+
+      expect(result).toBe('apps/my-app');
+    });
+
+    it('should handle paths without leading slash', () => {
+      const rootPath = getRootPath();
+      const fullPath = `${rootPath}/apps/my-app`;
+
+      const result = getProjectPath(fullPath);
+
+      expect(result).toBe('apps/my-app');
+    });
+
+    it('should return the path as-is if root path is not present', () => {
+      const projectPath = '/different/root/apps/my-app';
+
+      const result = getProjectPath(projectPath);
+
+      // Should remove the first slash
+      expect(result).toBe('different/root/apps/my-app');
+    });
+
+    it('should handle relative paths', () => {
+      const projectPath = 'apps/my-app';
+
+      const result = getProjectPath(projectPath);
+
+      // Note: The function removes the first '/' it finds, even in relative paths
+      // This results in removing the slash between 'apps' and 'my-app'
+      expect(result).toBe('appsmy-app');
+    });
+  });
+});

--- a/packages/scaffold-mcp/vitest.config.ts
+++ b/packages/scaffold-mcp/vitest.config.ts
@@ -12,10 +12,14 @@ export default defineConfig({
       exclude: ['node_modules/', 'tests/', 'dist/', '**/*.d.ts', '**/*.config.*', '**/index.ts'],
     },
     include: ['tests/**/*.test.ts'],
+    alias: {
+      'fs-extra': path.resolve(__dirname, './tests/__mocks__/fs-extra.ts'),
+    },
   },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      'fs-extra': path.resolve(__dirname, './tests/__mocks__/fs-extra.ts'),
     },
   },
 });


### PR DESCRIPTION
Add two extra prompts for slash commands: 
- scaffold-application: use this as slash command to create a new application from template using list-boilerplates and use-boilerplate tools.
- scaffold-feature: use this as slash command to create new feature using list-scaffolding-methods and use-scaffolding-method.