### PR TITLE
fix: correct README monolith documentation and improve terminal color visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ Experiment with these layers to find the right balance for your project. There's
 
 Get started with AI Code Toolkit in 3 simple steps:
 
-#### Step 1: Initialize Templates
+#### Step 1: Initialize Templates (or Create New Project)
+
+**For Existing Projects:**
 
 Run the init command to download official templates:
 
@@ -125,6 +127,20 @@ npx @agiflowai/scaffold-mcp init
 ```
 
 This automatically downloads official templates (Next.js 15, TypeScript libraries, MCP packages) to your workspace.
+
+**For New Projects:**
+
+Run init without a git repository and it will guide you through creating a new project:
+
+```bash
+# Interactive mode (recommended)
+npx @agiflowai/scaffold-mcp init
+
+# Non-interactive mode
+npx @agiflowai/scaffold-mcp init --name my-project --project-type monolith
+```
+
+The command will prompt you for project details, initialize git, and download templates.
 
 #### Step 2: Configure MCP Servers
 
@@ -240,21 +256,38 @@ sourceTemplate: react-vite  # Your template identifier
 
 ### Creating Projects
 
-**Monorepo** (default behavior):
+**New Project with Interactive Setup** (recommended):
 ```bash
-scaffold-mcp boilerplate create scaffold-nextjs-app \
-  --vars '{"appName": "web-app", "description": "Web App"}'
+# Run init without a git repository - it will prompt for project details
+npx @agiflowai/scaffold-mcp init
 
-# Creates: apps/web-app/project.json + project files
+# Interactive prompts will ask for:
+# - Project name
+# - Project type (monolith or monorepo)
+# - Git repository setup
+# - Template download
 ```
 
-**Monolith** (use `--monolith` flag):
+**New Project with CLI Options** (non-interactive):
 ```bash
-scaffold-mcp boilerplate create scaffold-react-vite-app \
-  --vars '{"appName": "my-app", "description": "My App"}' \
-  --monolith
+# Create a monolith project
+npx @agiflowai/scaffold-mcp init \
+  --name my-app \
+  --project-type monolith
 
-# Creates: toolkit.yaml + project files at workspace root
+# Create a monorepo project
+npx @agiflowai/scaffold-mcp init \
+  --name my-workspace \
+  --project-type monorepo
+```
+
+**Existing Workspace** (just initialize templates):
+```bash
+# In an existing git repository
+npx @agiflowai/scaffold-mcp init
+
+# With custom templates path
+npx @agiflowai/scaffold-mcp init --path custom-templates
 ```
 
 ### Adding Features
@@ -276,7 +309,7 @@ scaffold-mcp scaffold add scaffold-react-component \
 **Key Points**:
 - Templates are **architecture-agnostic** (same templates work for both)
 - Tools **auto-detect** project type from configuration files
-- Use `--monolith` flag only when **creating new projects**
+- Use `--project-type monolith` option when creating new projects with `init` command
 - Configuration priority: `project.json` → `toolkit.yaml` → `package.json`
 
 ---

--- a/packages/aicode-utils/src/utils/print.ts
+++ b/packages/aicode-utils/src/utils/print.ts
@@ -53,17 +53,17 @@ export const print = {
   },
 
   /**
-   * Log item in a list (gray with prefix)
+   * Log item in a list (white with prefix)
    */
   item: (message: string) => {
-    console.log(chalk.gray(`   - ${message}`));
+    console.log(chalk.white(`   - ${message}`));
   },
 
   /**
-   * Log indented text (gray)
+   * Log indented text (white)
    */
   indent: (message: string) => {
-    console.log(chalk.gray(`   ${message}`));
+    console.log(chalk.white(`   ${message}`));
   },
 
   /**


### PR DESCRIPTION
## Summary

- Fixed README.md to reflect actual CLI options (`--project-type monolith` instead of incorrect `--monolith` flag)
- Updated Quick Start section to distinguish between new projects and existing workspaces
- Improved terminal color visibility by changing gray to white in print utilities

## Changes

### Documentation Fixes (README.md)
- ✅ Corrected "Creating Projects" section with proper CLI options
- ✅ Updated Quick Start to show both interactive and non-interactive modes
- ✅ Fixed "Key Points" section reference to correct flag

### Terminal Color Improvements (print.ts)
- ✅ Changed `chalk.gray()` to `chalk.white()` for `print.indent()` and `print.item()`
- ✅ Improves visibility on dark terminal backgrounds (iTerm2, dark themes)

## Test Plan

- [x] Built all packages successfully
- [x] All tests pass (54 tests)
- [x] Verified color changes in terminal output
- [x] Documentation matches actual implementation in `init.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)