### PR TITLE
fix(one-mcp): auto-reconnect to downstream HTTP servers on stale session

### DIFF
--- a/packages/one-mcp/src/services/McpClientManagerService.ts
+++ b/packages/one-mcp/src/services/McpClientManagerService.ts
@@ -37,6 +37,15 @@ import type {
 const DEFAULT_CONNECTION_TIMEOUT_MS = 30000;
 
 /**
+ * Checks if an error is a session-related error from an HTTP backend
+ * (e.g., downstream server restarted and no longer recognizes the session ID).
+ */
+function isSessionError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes('unknown session') || message.includes('Session not found');
+}
+
+/**
  * MCP Client wrapper for managing individual server connections
  * This is an internal class used by McpClientManagerService
  */
@@ -50,6 +59,7 @@ class McpClient implements McpClientConnection {
   private client: Client;
   private childProcess?: ChildProcess;
   private connected: boolean = false;
+  private reconnectFn?: () => Promise<{ client: Client; childProcess?: ChildProcess }>;
 
   constructor(
     serverName: string,
@@ -79,49 +89,101 @@ class McpClient implements McpClientConnection {
     this.connected = connected;
   }
 
+  /**
+   * Sets a reconnection function that creates a fresh Client and transport.
+   * Called automatically by withSessionRetry when a session error is detected
+   * (e.g., downstream HTTP server restarted and the old session ID is invalid).
+   */
+  setReconnectFn(fn: () => Promise<{ client: Client; childProcess?: ChildProcess }>): void {
+    this.reconnectFn = fn;
+  }
+
+  /**
+   * Wraps an operation with automatic retry on session errors.
+   * If the operation fails with a session error (e.g., downstream server restarted),
+   * reconnects and retries once.
+   */
+  private async withSessionRetry<T>(operation: () => Promise<T>): Promise<T> {
+    try {
+      return await operation();
+    } catch (error) {
+      if (!this.reconnectFn || !isSessionError(error)) {
+        throw error;
+      }
+      console.error(
+        `Session error for ${this.serverName}, reconnecting: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      try {
+        await this.client.close();
+      } catch (closeError) {
+        // Safe to ignore: the stale client's transport is already broken,
+        // so close() may fail with the same session error or a network error.
+        console.error(`Failed to close stale client for ${this.serverName}:`, closeError);
+      }
+      const result = await this.reconnectFn();
+      this.client = result.client;
+      if (result.childProcess) {
+        this.childProcess = result.childProcess;
+      }
+      return await operation();
+    }
+  }
+
   async listTools(): Promise<any[]> {
     if (!this.connected) {
       throw new Error(`Client for ${this.serverName} is not connected`);
     }
-    const response = await this.client.listTools();
-    return response.tools;
+    return this.withSessionRetry(async () => {
+      const response = await this.client.listTools();
+      return response.tools;
+    });
   }
 
   async listResources(): Promise<any[]> {
     if (!this.connected) {
       throw new Error(`Client for ${this.serverName} is not connected`);
     }
-    const response = await this.client.listResources();
-    return response.resources;
+    return this.withSessionRetry(async () => {
+      const response = await this.client.listResources();
+      return response.resources;
+    });
   }
 
   async listPrompts(): Promise<any[]> {
     if (!this.connected) {
       throw new Error(`Client for ${this.serverName} is not connected`);
     }
-    const response = await this.client.listPrompts();
-    return response.prompts;
+    return this.withSessionRetry(async () => {
+      const response = await this.client.listPrompts();
+      return response.prompts;
+    });
   }
 
   async callTool(name: string, args: any): Promise<any> {
     if (!this.connected) {
       throw new Error(`Client for ${this.serverName} is not connected`);
     }
-    return await this.client.callTool({ name, arguments: args });
+    return this.withSessionRetry(async () => {
+      return await this.client.callTool({ name, arguments: args });
+    });
   }
 
   async readResource(uri: string): Promise<any> {
     if (!this.connected) {
       throw new Error(`Client for ${this.serverName} is not connected`);
     }
-    return await this.client.readResource({ uri });
+    return this.withSessionRetry(async () => {
+      return await this.client.readResource({ uri });
+    });
   }
 
   async getPrompt(name: string, args?: any): Promise<any> {
     if (!this.connected) {
       throw new Error(`Client for ${this.serverName} is not connected`);
     }
-    return await this.client.getPrompt({ name, arguments: args });
+    return this.withSessionRetry(async () => {
+      return await this.client.getPrompt({ name, arguments: args });
+    });
   }
 
   async close(): Promise<void> {
@@ -249,6 +311,26 @@ export class McpClientManagerService {
       ]);
 
       mcpClient.setConnected(true);
+
+      // Set up reconnection for HTTP/SSE transports (session-based backends).
+      // When a downstream server restarts, its old session IDs become invalid.
+      // This callback creates a fresh Client+transport so withSessionRetry can recover.
+      if (config.transport === 'http' || config.transport === 'sse') {
+        mcpClient.setReconnectFn(async () => {
+          try {
+            const newClient = new Client(
+              { name: '@agiflowai/one-mcp-client', version: '0.1.0' },
+              { capabilities: {} },
+            );
+            const newMcpClient = new McpClient(serverName, config.transport, newClient, {});
+            await this.performConnection(newMcpClient, config);
+            return { client: newClient };
+          } catch (error) {
+            console.error(`Failed to reconnect to ${serverName}:`, error);
+            throw error;
+          }
+        });
+      }
 
       // Get server instruction from MCP server if config instruction is not provided
       if (!mcpClient.serverInstruction) {

--- a/packages/one-mcp/tests/services/mcpClientManagerService.test.ts
+++ b/packages/one-mcp/tests/services/mcpClientManagerService.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { McpClientManagerService } from '../../src/services/McpClientManagerService';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import type { McpServerConfig } from '../../src/types';
+
+// Track all created mock client instances
+let mockClientInstances: Array<Record<string, ReturnType<typeof vi.fn>>> = [];
+
+function createMockClientInstance(): Record<string, ReturnType<typeof vi.fn>> {
+  const instance = {
+    connect: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'test_tool' }] }),
+    callTool: vi.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] }),
+    listResources: vi.fn().mockResolvedValue({ resources: [] }),
+    listPrompts: vi.fn().mockResolvedValue({ prompts: [] }),
+    readResource: vi.fn().mockResolvedValue({ contents: [] }),
+    getPrompt: vi.fn().mockResolvedValue({ messages: [] }),
+    getInstructions: vi.fn().mockReturnValue(undefined),
+  };
+  mockClientInstances.push(instance);
+  return instance;
+}
+
+// Mock the SDK transports
+vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: class MockHTTPTransport {
+    constructor() {}
+  },
+}));
+vi.mock('@modelcontextprotocol/sdk/client/sse.js', () => ({
+  SSEClientTransport: class MockSSETransport {
+    constructor() {}
+  },
+}));
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: class MockStdioTransport {
+    constructor() {}
+  },
+}));
+
+// Mock the Client class as a proper constructor
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: class MockClient {
+    [key: string]: ReturnType<typeof vi.fn> | undefined;
+    constructor() {
+      const instance = createMockClientInstance();
+      Object.assign(this, instance);
+    }
+  },
+}));
+
+const httpConfig: McpServerConfig = {
+  name: 'http-server',
+  transport: 'http',
+  config: { url: 'http://localhost:3000/mcp' },
+};
+
+const stdioConfig: McpServerConfig = {
+  name: 'stdio-server',
+  transport: 'stdio',
+  config: { command: 'node', args: ['server.js'] },
+};
+
+describe('McpClientManagerService', () => {
+  let service: McpClientManagerService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClientInstances = [];
+    service = new McpClientManagerService();
+  });
+
+  describe('session retry on HTTP transport', () => {
+    it('should reconnect and retry when callTool gets a session error', async () => {
+      await service.connectToServer('http-server', httpConfig);
+
+      const client = service.getClient('http-server');
+      expect(client).toBeDefined();
+      if (!client) return;
+
+      expect(mockClientInstances).toHaveLength(1);
+      const firstInstance = mockClientInstances[0];
+
+      // Make callTool fail with a session error on the first client
+      firstInstance.callTool.mockRejectedValueOnce(
+        new Error(
+          'Streamable HTTP error: Error POSTing to endpoint: {"jsonrpc":"2.0","error":{"code":-32000,"message":"Bad Request: unknown session ID \'abc123\'."},"id":null}',
+        ),
+      );
+
+      // The retry after reconnection should succeed
+      const result = await client.callTool('test_tool', {});
+      expect(result).toBeDefined();
+
+      // Should have created a second Client for the reconnection
+      expect(mockClientInstances).toHaveLength(2);
+    });
+
+    it('should reconnect and retry when listTools gets a session error', async () => {
+      await service.connectToServer('http-server', httpConfig);
+
+      const client = service.getClient('http-server');
+      expect(client).toBeDefined();
+      if (!client) return;
+
+      const firstInstance = mockClientInstances[0];
+      firstInstance.listTools.mockRejectedValueOnce(
+        new Error('Bad Request: unknown session ID'),
+      );
+
+      const tools = await client.listTools();
+      expect(tools).toBeDefined();
+      expect(mockClientInstances).toHaveLength(2);
+    });
+
+    it('should not retry on non-session errors', async () => {
+      await service.connectToServer('http-server', httpConfig);
+
+      const client = service.getClient('http-server');
+      expect(client).toBeDefined();
+      if (!client) return;
+
+      const firstInstance = mockClientInstances[0];
+      firstInstance.callTool.mockRejectedValue(new Error('Network timeout'));
+
+      await expect(client.callTool('test_tool', {})).rejects.toThrow('Network timeout');
+      // Should NOT have created a second Client
+      expect(mockClientInstances).toHaveLength(1);
+    });
+
+    it('should not set up reconnect for stdio transport', async () => {
+      await service.connectToServer('stdio-server', stdioConfig);
+
+      const client = service.getClient('stdio-server');
+      expect(client).toBeDefined();
+      if (!client) return;
+
+      const firstInstance = mockClientInstances[0];
+      firstInstance.callTool.mockRejectedValue(
+        new Error('Bad Request: unknown session ID'),
+      );
+
+      // Should throw without retrying since stdio has no reconnect
+      await expect(client.callTool('test_tool', {})).rejects.toThrow('unknown session');
+      expect(mockClientInstances).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- When a downstream HTTP/SSE MCP server restarts, one-mcp's cached client retains a stale session ID, causing all requests to fail with `"unknown session ID"`
- Adds transparent `withSessionRetry` logic in `McpClient` that detects session errors, creates a fresh connection, and retries the operation once
- Reconnect is wired up only for HTTP/SSE transports (stdio has no sessions)

## Test plan
- [x] 4 new unit tests covering: callTool retry, listTools retry, no retry on non-session errors, no reconnect for stdio
- [x] All 324 existing tests pass
- [x] Build succeeds
- [ ] Manual integration test: start one-mcp with HTTP backend, restart backend, verify tool calls auto-recover