### PR TITLE
feat(one-mcp): add per-request timeout for tool calls

### DIFF
--- a/packages/one-mcp/src/commands/use-tool.ts
+++ b/packages/one-mcp/src/commands/use-tool.ts
@@ -35,6 +35,7 @@ export const useToolCommand = new Command('use-tool')
   .option('-c, --config <path>', 'Path to MCP server configuration file')
   .option('-s, --server <name>', 'Server name (required if tool exists on multiple servers)')
   .option('-a, --args <json>', 'Tool arguments as JSON string', '{}')
+  .option('-t, --timeout <ms>', 'Request timeout in milliseconds for tool execution (default: 60000)', parseInt)
   .option('-j, --json', 'Output as JSON', false)
   .action(async (toolName: string, options) => {
     try {
@@ -64,20 +65,18 @@ export const useToolCommand = new Command('use-tool')
       const clientManager = new McpClientManagerService();
 
       // Connect to all configured MCP servers
-      const connectionPromises = Object.entries(config.mcpServers).map(
-        async ([serverName, serverConfig]) => {
-          try {
-            await clientManager.connectToServer(serverName, serverConfig);
-            if (!options.json) {
-              console.error(`✓ Connected to ${serverName}`);
-            }
-          } catch (error) {
-            if (!options.json) {
-              console.error(`✗ Failed to connect to ${serverName}:`, error);
-            }
+      const connectionPromises = Object.entries(config.mcpServers).map(async ([serverName, serverConfig]) => {
+        try {
+          await clientManager.connectToServer(serverName, serverConfig);
+          if (!options.json) {
+            console.error(`✓ Connected to ${serverName}`);
           }
-        },
-      );
+        } catch (error) {
+          if (!options.json) {
+            console.error(`✗ Failed to connect to ${serverName}:`, error);
+          }
+        }
+      });
 
       await Promise.all(connectionPromises);
 
@@ -101,7 +100,8 @@ export const useToolCommand = new Command('use-tool')
             console.error(`Executing ${toolName} on ${options.server}...`);
           }
 
-          const result = await client.callTool(toolName, toolArgs);
+          const requestOptions = options.timeout ? { timeout: options.timeout } : undefined;
+          const result = await client.callTool(toolName, toolArgs, requestOptions);
 
           if (options.json) {
             console.log(JSON.stringify(result, null, 2));
@@ -166,9 +166,7 @@ export const useToolCommand = new Command('use-tool')
           try {
             const skillService = new SkillService(cwd, skillPaths);
             // Handle skill__ prefix
-            const skillName = toolName.startsWith('skill__')
-              ? toolName.slice('skill__'.length)
-              : toolName;
+            const skillName = toolName.startsWith('skill__') ? toolName.slice('skill__'.length) : toolName;
 
             const skill = await skillService.getSkill(skillName);
             if (skill) {
@@ -199,17 +197,13 @@ export const useToolCommand = new Command('use-tool')
           }
         }
 
-        console.error(
-          `Tool or skill "${toolName}" not found on any connected server or configured skill paths`,
-        );
+        console.error(`Tool or skill "${toolName}" not found on any connected server or configured skill paths`);
         await clientManager.disconnectAll();
         process.exit(1);
       }
 
       if (matchingServers.length > 1) {
-        console.error(
-          `Tool "${toolName}" found on multiple servers: ${matchingServers.join(', ')}`,
-        );
+        console.error(`Tool "${toolName}" found on multiple servers: ${matchingServers.join(', ')}`);
         console.error('Please specify --server to disambiguate');
         await clientManager.disconnectAll();
         process.exit(1);
@@ -230,7 +224,8 @@ export const useToolCommand = new Command('use-tool')
           console.error(`Executing ${toolName} on ${targetServer}...`);
         }
 
-        const result = await client.callTool(toolName, toolArgs);
+        const requestOpts = options.timeout ? { timeout: options.timeout } : undefined;
+        const result = await client.callTool(toolName, toolArgs, requestOpts);
 
         if (options.json) {
           console.log(JSON.stringify(result, null, 2));

--- a/packages/one-mcp/src/services/McpClientManagerService.ts
+++ b/packages/one-mcp/src/services/McpClientManagerService.ts
@@ -20,16 +20,16 @@
 
 import type { ChildProcess } from 'node:child_process';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import type {
-  McpServerConfig,
-  McpStdioConfig,
-  McpHttpConfig,
-  McpSseConfig,
   McpClientConnection,
+  McpHttpConfig,
+  McpServerConfig,
   McpServerTransportType,
+  McpSseConfig,
+  McpStdioConfig,
   PromptConfig,
 } from '../types';
 
@@ -159,12 +159,13 @@ class McpClient implements McpClientConnection {
     });
   }
 
-  async callTool(name: string, args: any): Promise<any> {
+  async callTool(name: string, args: any, options?: { timeout?: number }): Promise<any> {
     if (!this.connected) {
       throw new Error(`Client for ${this.serverName} is not connected`);
     }
     return this.withSessionRetry(async () => {
-      return await this.client.callTool({ name, arguments: args });
+      const requestOptions = options?.timeout ? { timeout: options.timeout } : undefined;
+      return await this.client.callTool({ name, arguments: args }, undefined, requestOptions);
     });
   }
 
@@ -220,9 +221,7 @@ export class McpClientManagerService {
           // Force kill after timeout if process doesn't exit
           setTimeout(() => {
             if (!childProcess.killed) {
-              console.error(
-                `Force killing stdio MCP server: ${serverName} (PID: ${childProcess.pid})`,
-              );
+              console.error(`Force killing stdio MCP server: ${serverName} (PID: ${childProcess.pid})`);
               childProcess.kill('SIGKILL');
             }
           }, 1000);
@@ -252,6 +251,10 @@ export class McpClientManagerService {
     return Array.from(this.serverConfigs.keys());
   }
 
+  getServerRequestTimeout(serverName: string): number | undefined {
+    return this.serverConfigs.get(serverName)?.requestTimeout;
+  }
+
   async ensureConnected(serverName: string): Promise<McpClientConnection> {
     const existingClient = this.clients.get(serverName);
     if (existingClient) {
@@ -278,10 +281,7 @@ export class McpClientManagerService {
     }
   }
 
-  private async createConnection(
-    serverName: string,
-    config: McpServerConfig,
-  ): Promise<McpClient> {
+  private async createConnection(serverName: string, config: McpServerConfig): Promise<McpClient> {
     const timeoutMs = config.timeout ?? DEFAULT_CONNECTION_TIMEOUT_MS;
 
     const client = new Client(
@@ -318,10 +318,7 @@ export class McpClientManagerService {
       if (config.transport === 'http' || config.transport === 'sse') {
         mcpClient.setReconnectFn(async () => {
           try {
-            const newClient = new Client(
-              { name: '@agiflowai/one-mcp-client', version: '0.1.0' },
-              { capabilities: {} },
-            );
+            const newClient = new Client({ name: '@agiflowai/one-mcp-client', version: '0.1.0' }, { capabilities: {} });
             const newMcpClient = new McpClient(serverName, config.transport, newClient, {});
             await this.performConnection(newMcpClient, config);
             return { client: newClient };

--- a/packages/one-mcp/src/tools/UseToolTool.ts
+++ b/packages/one-mcp/src/tools/UseToolTool.ts
@@ -24,12 +24,12 @@
  */
 
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import type { Tool, ToolDefinition, Skill, PromptSkillConfig } from '../types';
+import { DEFAULT_SERVER_ID, SKILL_PREFIX } from '../constants';
+import { DefinitionsCacheService } from '../services/DefinitionsCacheService';
 import type { McpClientManagerService } from '../services/McpClientManagerService';
 import type { SkillService } from '../services/SkillService';
-import { DefinitionsCacheService } from '../services/DefinitionsCacheService';
+import type { PromptSkillConfig, Skill, Tool, ToolDefinition } from '../types';
 import { parseToolName } from '../utils';
-import { DEFAULT_SERVER_ID, SKILL_PREFIX } from '../constants';
 
 /**
  * Result of finding a prompt-based skill configuration
@@ -88,8 +88,7 @@ export class UseToolTool implements Tool<UseToolToolInput> {
   ) {
     this.clientManager = clientManager;
     this.skillService = skillService;
-    this.definitionsCacheService =
-      definitionsCacheService || new DefinitionsCacheService(clientManager, skillService);
+    this.definitionsCacheService = definitionsCacheService || new DefinitionsCacheService(clientManager, skillService);
     this.serverId = serverId || DEFAULT_SERVER_ID;
   }
 
@@ -168,8 +167,7 @@ IMPORTANT: Only use tools discovered from describe_tools with id="${this.serverI
    * @returns CallToolResult with guidance message
    */
   private executePromptSkill(promptSkill: PromptSkillMatch): CallToolResult {
-    const location =
-      promptSkill.skill.folder || `prompt:${promptSkill.serverName}/${promptSkill.promptName}`;
+    const location = promptSkill.skill.folder || `prompt:${promptSkill.serverName}/${promptSkill.promptName}`;
     return {
       content: [
         {
@@ -252,7 +250,12 @@ IMPORTANT: Only use tools discovered from describe_tools with id="${this.serverI
             };
           }
 
-          const result = await client.callTool(actualToolName, toolArgs);
+          const reqTimeout = this.clientManager.getServerRequestTimeout(serverName);
+          const result = await client.callTool(
+            actualToolName,
+            toolArgs,
+            reqTimeout ? { timeout: reqTimeout } : undefined,
+          );
           return result;
         } catch (error) {
           return {
@@ -316,7 +319,12 @@ IMPORTANT: Only use tools discovered from describe_tools with id="${this.serverI
       try {
         const targetServerName = matchingServers[0];
         const client = await this.clientManager.ensureConnected(targetServerName);
-        const result = await client.callTool(actualToolName, toolArgs);
+        const targetReqTimeout = this.clientManager.getServerRequestTimeout(targetServerName);
+        const result = await client.callTool(
+          actualToolName,
+          toolArgs,
+          targetReqTimeout ? { timeout: targetReqTimeout } : undefined,
+        );
         return result;
       } catch (error) {
         return {

--- a/packages/one-mcp/src/types/index.ts
+++ b/packages/one-mcp/src/types/index.ts
@@ -10,11 +10,7 @@
  * - Use descriptive names for types and interfaces
  */
 
-import type {
-  CallToolResult,
-  ReadResourceResult,
-  GetPromptResult,
-} from '@modelcontextprotocol/sdk/types.js';
+import type { CallToolResult, GetPromptResult, ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
 
 /**
  * Tool definition for MCP
@@ -255,6 +251,8 @@ export interface McpServerConfig {
   transport: McpServerTransportType;
   config: McpServerTransportConfig;
   timeout?: number;
+  /** Optional per-request timeout in milliseconds for tool calls (default: 60000 from MCP SDK) */
+  requestTimeout?: number;
   disabled?: boolean;
 }
 
@@ -364,7 +362,7 @@ export interface McpClientConnection {
   /** List available prompts from the server */
   listPrompts(): Promise<McpPromptInfo[]>;
   /** Call a tool with the given name and arguments */
-  callTool(name: string, args: Record<string, unknown>): Promise<CallToolResult>;
+  callTool(name: string, args: Record<string, unknown>, options?: { timeout?: number }): Promise<CallToolResult>;
   /** Read a resource by URI */
   readResource(uri: string): Promise<ReadResourceResult>;
   /** Get a prompt by name with optional arguments */

--- a/packages/one-mcp/src/utils/mcpConfigSchema.ts
+++ b/packages/one-mcp/src/utils/mcpConfigSchema.ts
@@ -160,9 +160,7 @@ function validateUrlSecurity(url: string, security?: RemoteConfigSource['securit
   }
 
   if (protocol !== 'http' && protocol !== 'https') {
-    throw new Error(
-      `Invalid URL protocol '${protocol}://'. Only http:// and https:// are allowed.`,
-    );
+    throw new Error(`Invalid URL protocol '${protocol}://'. Only http:// and https:// are allowed.`);
   }
 
   // Check for private IPs and localhost (unless explicitly allowed)
@@ -277,6 +275,7 @@ const ClaudeCodeStdioServerSchema = z.object({
   disabled: z.boolean().optional(),
   instruction: z.string().optional(), // Top-level instruction (user override)
   timeout: z.number().positive().optional(), // Connection timeout in milliseconds
+  requestTimeout: z.number().positive().optional(), // Per-request timeout for tool calls in milliseconds
   config: AdditionalConfigSchema, // Nested config with server's default instruction
 });
 
@@ -288,14 +287,12 @@ const ClaudeCodeHttpServerSchema = z.object({
   disabled: z.boolean().optional(),
   instruction: z.string().optional(), // Top-level instruction (user override)
   timeout: z.number().positive().optional(), // Connection timeout in milliseconds
+  requestTimeout: z.number().positive().optional(), // Per-request timeout for tool calls in milliseconds
   config: AdditionalConfigSchema, // Nested config with server's default instruction
 });
 
 // Union of all Claude Code server types
-const ClaudeCodeServerConfigSchema = z.union([
-  ClaudeCodeStdioServerSchema,
-  ClaudeCodeHttpServerSchema,
-]);
+const ClaudeCodeServerConfigSchema = z.union([ClaudeCodeStdioServerSchema, ClaudeCodeHttpServerSchema]);
 
 // Remote config validation schema
 const RemoteConfigValidationSchema = z
@@ -392,6 +389,7 @@ const McpServerConfigSchema = z.discriminatedUnion('transport', [
     omitToolDescription: z.boolean().optional(),
     prompts: z.record(z.string(), InternalPromptConfigSchema).optional(),
     timeout: z.number().positive().optional(),
+    requestTimeout: z.number().positive().optional(),
     transport: z.literal('stdio'),
     config: McpStdioConfigSchema,
   }),
@@ -402,6 +400,7 @@ const McpServerConfigSchema = z.discriminatedUnion('transport', [
     omitToolDescription: z.boolean().optional(),
     prompts: z.record(z.string(), InternalPromptConfigSchema).optional(),
     timeout: z.number().positive().optional(),
+    requestTimeout: z.number().positive().optional(),
     transport: z.literal('http'),
     config: McpHttpConfigSchema,
   }),
@@ -412,6 +411,7 @@ const McpServerConfigSchema = z.discriminatedUnion('transport', [
     omitToolDescription: z.boolean().optional(),
     prompts: z.record(z.string(), InternalPromptConfigSchema).optional(),
     timeout: z.number().positive().optional(),
+    requestTimeout: z.number().positive().optional(),
     transport: z.literal('sse'),
     config: McpSseConfigSchema,
   }),
@@ -455,9 +455,7 @@ export function transformClaudeCodeConfig(claudeConfig: ClaudeCodeMcpConfig): In
       // Interpolate environment variables in command, args, and env
       const interpolatedCommand = interpolateEnvVars(stdioConfig.command);
       const interpolatedArgs = stdioConfig.args?.map((arg) => interpolateEnvVars(arg));
-      const interpolatedEnv = stdioConfig.env
-        ? interpolateEnvVarsInObject(stdioConfig.env)
-        : undefined;
+      const interpolatedEnv = stdioConfig.env ? interpolateEnvVarsInObject(stdioConfig.env) : undefined;
 
       // Instruction priority: top-level instruction (user override) > config.instruction (server default)
       const finalInstruction = stdioConfig.instruction || stdioConfig.config?.instruction;
@@ -465,6 +463,7 @@ export function transformClaudeCodeConfig(claudeConfig: ClaudeCodeMcpConfig): In
       const omitToolDescription = stdioConfig.config?.omitToolDescription;
       const prompts = stdioConfig.config?.prompts;
       const timeout = stdioConfig.timeout;
+      const requestTimeout = stdioConfig.requestTimeout;
 
       transformedServers[serverName] = {
         name: serverName,
@@ -473,6 +472,7 @@ export function transformClaudeCodeConfig(claudeConfig: ClaudeCodeMcpConfig): In
         omitToolDescription,
         prompts,
         timeout,
+        requestTimeout,
         transport: 'stdio' as const,
         config: {
           command: interpolatedCommand,
@@ -487,9 +487,7 @@ export function transformClaudeCodeConfig(claudeConfig: ClaudeCodeMcpConfig): In
 
       // Interpolate environment variables in URL and headers
       const interpolatedUrl = interpolateEnvVars(httpConfig.url);
-      const interpolatedHeaders = httpConfig.headers
-        ? interpolateEnvVarsInObject(httpConfig.headers)
-        : undefined;
+      const interpolatedHeaders = httpConfig.headers ? interpolateEnvVarsInObject(httpConfig.headers) : undefined;
 
       // Instruction priority: top-level instruction (user override) > config.instruction (server default)
       const finalInstruction = httpConfig.instruction || httpConfig.config?.instruction;
@@ -497,6 +495,7 @@ export function transformClaudeCodeConfig(claudeConfig: ClaudeCodeMcpConfig): In
       const omitToolDescription = httpConfig.config?.omitToolDescription;
       const prompts = httpConfig.config?.prompts;
       const timeout = httpConfig.timeout;
+      const requestTimeout = httpConfig.requestTimeout;
 
       transformedServers[serverName] = {
         name: serverName,
@@ -505,6 +504,7 @@ export function transformClaudeCodeConfig(claudeConfig: ClaudeCodeMcpConfig): In
         omitToolDescription,
         prompts,
         timeout,
+        requestTimeout,
         transport,
         config: {
           url: interpolatedUrl,

--- a/packages/one-mcp/tests/server/flatModeHandlers.test.ts
+++ b/packages/one-mcp/tests/server/flatModeHandlers.test.ts
@@ -47,6 +47,7 @@ vi.mock('../../src/services/McpClientManagerService', () => ({
     getKnownServerNames = vi.fn(() => ['alpha', 'beta']);
     getAllClients = vi.fn(() => []);
     getClient = vi.fn(() => undefined);
+    getServerRequestTimeout = vi.fn(() => undefined);
   },
 }));
 
@@ -285,7 +286,7 @@ describe('createServer flat mode handlers', () => {
     });
 
     expect(mocks.mockEnsureConnected).toHaveBeenCalledWith('beta');
-    expect(mocks.mockConnectedClient?.callTool).toHaveBeenCalledWith('status', { verbose: true });
+    expect(mocks.mockConnectedClient?.callTool).toHaveBeenCalledWith('status', { verbose: true }, undefined);
   });
 
   it('returns an error when a clashing flat tool is called without a prefix', async () => {

--- a/packages/one-mcp/tests/tools/UseToolTool.test.ts
+++ b/packages/one-mcp/tests/tools/UseToolTool.test.ts
@@ -38,6 +38,7 @@ describe('UseToolTool', () => {
       getKnownServerNames: vi.fn().mockReturnValue(['server-a']),
       ensureConnected: vi.fn().mockResolvedValue(connectedClient),
       getAllClients: vi.fn().mockReturnValue([]),
+      getServerRequestTimeout: vi.fn().mockReturnValue(undefined),
     } as unknown as McpClientManagerService;
     mockSkillService = {
       getSkill: vi.fn(),
@@ -82,7 +83,7 @@ describe('UseToolTool', () => {
     });
 
     expect(mockClientManager.ensureConnected).toHaveBeenCalledWith('server-a');
-    expect(connectedClient.callTool).toHaveBeenCalledWith('cached_tool', { foo: 'bar' });
+    expect(connectedClient.callTool).toHaveBeenCalledWith('cached_tool', { foo: 'bar' }, undefined);
     expect(connectedClient.listTools).not.toHaveBeenCalled();
     expect(result.isError).toBeUndefined();
   });


### PR DESCRIPTION
## Summary
- Add `requestTimeout` config option for MCP server definitions to customize per-request timeout for tool calls
- Add `--timeout` CLI flag for `use-tool` command to override timeout on individual invocations
- Pass timeout through to MCP SDK's `callTool` request options, allowing longer-running tools to complete beyond the default 60s

## Test plan
- [x] Existing unit tests updated to cover new `requestTimeout` parameter
- [x] Manual test: `use-tool --timeout 30000` executes successfully with custom timeout
- [x] Manual test: `use-tool --timeout 1` correctly triggers `MCP error -32001: Request timed out`
- [x] Manual test: `use-tool` without `--timeout` works with default timeout
- [x] Manual test: `--help` displays the new `--timeout` option correctly

Note: `requestTimeout` in config applies to proxy/server mode (`UseToolTool`), while `--timeout` CLI flag applies to direct CLI usage — tested both paths.