### PR TITLE
Fix dependency alerts and one-mcp shutdown cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,11 @@
       "minimatch": "10.2.5",
       "rollup": "4.60.1",
       "express-rate-limit": "8.3.2",
-      "liquidjs": "10.25.5"
+      "liquidjs": "10.25.5",
+      "follow-redirects": "1.16.0",
+      "path-to-regexp": "8.4.0",
+      "yaml@1": "1.10.3",
+      "yaml@>=2": "2.8.3"
     }
   }
 }

--- a/packages/architect-mcp/project.json
+++ b/packages/architect-mcp/project.json
@@ -1,7 +1,7 @@
 {
   "name": "@agiflowai/architect-mcp",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
-  "sourceRoot": "packages/architect-mcp",
+  "sourceRoot": "packages/architect-mcp/src",
   "projectType": "application",
   "targets": {
     "build": {
@@ -13,28 +13,28 @@
     },
     "test": {
       "executor": "@nx/vitest:test",
-      "outputs": ["{workspaceRoot}/coverage/packages/scaffold-mcp"],
+      "outputs": ["{workspaceRoot}/coverage/packages/architect-mcp"],
       "options": {
-        "reportsDirectory": "../../coverage/packages/scaffold-mcp"
+        "reportsDirectory": "../../coverage/packages/architect-mcp"
       }
     },
     "typecheck": {
       "executor": "nx:run-commands",
       "options": {
         "command": "tsc --noEmit",
-        "cwd": "packages/scaffold-mcp"
+        "cwd": "packages/architect-mcp"
       }
     },
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "biome check packages/scaffold-mcp"
+        "command": "biome check packages/architect-mcp"
       }
     },
     "lint:fix": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "biome check --write packages/scaffold-mcp"
+        "command": "biome check --write packages/architect-mcp"
       }
     }
   },

--- a/packages/architect-mcp/src/commands/hook.ts
+++ b/packages/architect-mcp/src/commands/hook.ts
@@ -20,7 +20,12 @@
  * - Not exiting with appropriate exit codes on errors
  */
 
-import { CLAUDE_CODE, GEMINI_CLI, SUPPORTED_LLM_TOOLS, isValidLlmTool } from '@agiflowai/coding-agent-bridge';
+import {
+  CLAUDE_CODE,
+  GEMINI_CLI,
+  SUPPORTED_LLM_TOOLS,
+  isValidLlmTool,
+} from '@agiflowai/coding-agent-bridge';
 import {
   ClaudeCodeAdapter,
   GeminiCliAdapter,
@@ -175,7 +180,9 @@ export const hookCommand = new Command('hook')
       const toolkitConfig = await TemplatesManagerService.readToolkitConfig();
       const hookConfig = toolkitConfig?.['architect-mcp']?.hook;
       const methodConfig =
-        hookConfig?.[agent as keyof ArchitectHookConfig]?.[hookMethod as keyof ArchitectHookAgentConfig];
+        hookConfig?.[agent as keyof ArchitectHookConfig]?.[
+          hookMethod as keyof ArchitectHookAgentConfig
+        ];
 
       // Parse JSON config options
       const toolConfig = parseJsonConfigOption(options.toolConfig, '--tool-config');
@@ -194,9 +201,7 @@ export const hookCommand = new Command('hook')
       const resolvedToolConfig = toolConfig ?? methodConfig?.['tool-config'] ?? fallbackToolConfig;
 
       if (!isHookMethod(hookMethod)) {
-        print.error(
-          `Unsupported hook method: ${hookMethod}. Supported: preToolUse, postToolUse`,
-        );
+        print.error(`Unsupported hook method: ${hookMethod}. Supported: preToolUse, postToolUse`);
         process.exit(1);
       }
 

--- a/packages/architect-mcp/src/commands/mcp-serve.ts
+++ b/packages/architect-mcp/src/commands/mcp-serve.ts
@@ -30,7 +30,11 @@ import {
   type TransportConfig,
   type TransportHandler,
 } from '../transports';
-import { type LlmToolId, isValidLlmTool, SUPPORTED_LLM_TOOLS } from '@agiflowai/coding-agent-bridge';
+import {
+  type LlmToolId,
+  isValidLlmTool,
+  SUPPORTED_LLM_TOOLS,
+} from '@agiflowai/coding-agent-bridge';
 
 /**
  * Options passed by Commander for the mcp-serve command
@@ -85,7 +89,10 @@ function parseLlmToolOption(value: string | undefined, flagName: string): LlmToo
 /**
  * Parse a JSON config string option. Throws on parse failure or non-object value.
  */
-function parseJsonConfig(value: string | undefined, flagName: string): Record<string, unknown> | undefined {
+function parseJsonConfig(
+  value: string | undefined,
+  flagName: string,
+): Record<string, unknown> | undefined {
   if (!value) return undefined;
   try {
     const parsed: unknown = JSON.parse(value);
@@ -94,7 +101,9 @@ function parseJsonConfig(value: string | undefined, flagName: string): Record<st
     }
     return parsed;
   } catch (error) {
-    throw new Error(`Invalid JSON for ${flagName}: ${error instanceof Error ? error.message : String(error)}`);
+    throw new Error(
+      `Invalid JSON for ${flagName}: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
 }
 
@@ -136,8 +145,12 @@ async function startServer(handler: TransportHandler): Promise<void> {
     }
   };
 
-  process.on('SIGINT', async (): Promise<void> => { await shutdown('SIGINT'); });
-  process.on('SIGTERM', async (): Promise<void> => { await shutdown('SIGTERM'); });
+  process.on('SIGINT', async (): Promise<void> => {
+    await shutdown('SIGINT');
+  });
+  process.on('SIGTERM', async (): Promise<void> => {
+    await shutdown('SIGTERM');
+  });
 }
 
 /**
@@ -146,10 +159,8 @@ async function startServer(handler: TransportHandler): Promise<void> {
 export const mcpServeCommand = new Command('mcp-serve')
   .description('Start MCP server with specified transport')
   .option('-t, --type <type>', 'Transport type: stdio, http, or sse')
-  .option(
-    '-p, --port <port>',
-    'Port to listen on (http/sse only)',
-    (val: string): number => parseInt(val, 10),
+  .option('-p, --port <port>', 'Port to listen on (http/sse only)', (val: string): number =>
+    parseInt(val, 10),
   )
   .option('--host <host>', 'Host to bind to (http/sse only)')
   .option(

--- a/packages/architect-mcp/tests/server/index.test.ts
+++ b/packages/architect-mcp/tests/server/index.test.ts
@@ -38,19 +38,13 @@ describe('architect-mcp server capability metadata', () => {
         expect.objectContaining({
           name: 'get-file-design-pattern',
           _meta: {
-            'agiflowai/capabilities': expect.arrayContaining([
-              'architecture',
-              'design-patterns',
-            ]),
+            'agiflowai/capabilities': expect.arrayContaining(['architecture', 'design-patterns']),
           },
         }),
         expect.objectContaining({
           name: 'review-code-change',
           _meta: {
-            'agiflowai/capabilities': expect.arrayContaining([
-              'code-review',
-              'quality-checks',
-            ]),
+            'agiflowai/capabilities': expect.arrayContaining(['code-review', 'quality-checks']),
           },
         }),
         expect.objectContaining({

--- a/packages/one-mcp/src/commands/stop.ts
+++ b/packages/one-mcp/src/commands/stop.ts
@@ -1,8 +1,8 @@
 /**
  * Stop Command
  *
- * Stops a running HTTP one-mcp server using the authenticated admin endpoint
- * and the persisted runtime registry.
+ * Stops a running HTTP one-mcp server using the persisted runtime registry
+ * and a local process signal.
  */
 
 import { Command } from 'commander';
@@ -16,7 +16,6 @@ interface StopCommandOptions {
   host?: string;
   port?: number;
   config?: string;
-  token?: string;
   force: boolean;
   json: boolean;
   timeout: number;
@@ -45,7 +44,6 @@ export const stopCommand = new Command('stop')
     (value: string): number => Number.parseInt(value, 10),
   )
   .option('-c, --config <path>', 'Reserved for future config-based targeting support')
-  .option('--token <token>', 'Override the persisted shutdown token')
   .option('--force', 'Skip server ID verification against the /health response', false)
   .option('-j, --json', 'Output as JSON', false)
   .option(
@@ -65,7 +63,6 @@ export const stopCommand = new Command('stop')
         serverId: options.id,
         host: options.host,
         port: options.port,
-        token: options.token,
         force: options.force,
         timeoutMs: options.timeout,
       });

--- a/packages/one-mcp/src/services/StopServerService/StopServerService.ts
+++ b/packages/one-mcp/src/services/StopServerService/StopServerService.ts
@@ -2,32 +2,23 @@
  * StopServerService
  *
  * Resolves a running HTTP one-mcp runtime and requests cooperative shutdown
- * through the authenticated admin endpoint.
+ * by signaling the recorded local process.
  */
 
-import type {
-  HttpTransportShutdownResponse,
-  RuntimeStateManager,
-  RuntimeStateRecord,
-} from '../../types';
+import type { RuntimeStateManager, RuntimeStateRecord } from '../../types';
 import { RuntimeStateService } from '../RuntimeStateService';
 import {
-  ADMIN_SHUTDOWN_PATH,
   ALLOWED_HOSTS,
-  AUTHORIZATION_HEADER_NAME,
-  BEARER_TOKEN_PREFIX,
   DEFAULT_STOP_TIMEOUT_MS,
   HEALTH_CHECK_PATH,
   HEALTH_REQUEST_TIMEOUT_FLOOR_MS,
   HTTP_METHOD_GET,
-  HTTP_METHOD_POST,
   HTTP_PROTOCOL,
   SHUTDOWN_POLL_INTERVAL_MS,
   URL_PORT_SEPARATOR,
 } from './constants';
 import {
   isHealthResponse,
-  isShutdownResponse,
   type HealthCheckResult,
   type StopServerRequest,
   type StopServerResult,
@@ -92,12 +83,7 @@ export class StopServerService {
       );
     }
 
-    const shutdownToken = request.token ?? runtime.shutdownToken;
-    if (!shutdownToken) {
-      throw new Error(`No shutdown token available for runtime '${runtime.serverId}'.`);
-    }
-
-    const shutdownResponse = await this.requestShutdown(runtime, shutdownToken, timeoutMs);
+    this.requestLocalShutdown(runtime);
     await this.waitForShutdown(runtime, timeoutMs);
     await this.runtimeStateService.remove(runtime.serverId);
 
@@ -106,7 +92,7 @@ export class StopServerService {
       serverId: runtime.serverId,
       host: runtime.host,
       port: runtime.port,
-      message: shutdownResponse.message,
+      message: `Sent SIGTERM to local process ${runtime.pid} and the runtime stopped gracefully.`,
     };
   }
 
@@ -187,39 +173,26 @@ export class StopServerService {
     }
   }
 
-  /**
-   * Send authenticated shutdown request to the admin endpoint.
-   * @param runtime - Runtime to stop
-   * @param shutdownToken - Bearer token for the admin endpoint
-   * @param timeoutMs - Request timeout in milliseconds
-   * @returns Parsed shutdown response payload
-   */
-  private async requestShutdown(
-    runtime: RuntimeStateRecord,
-    shutdownToken: string,
-    timeoutMs: number,
-  ): Promise<HttpTransportShutdownResponse> {
-    const response = await this.fetchWithTimeout(
-      buildRuntimeUrl(runtime, ADMIN_SHUTDOWN_PATH),
-      {
-        method: HTTP_METHOD_POST,
-        headers: {
-          [AUTHORIZATION_HEADER_NAME]: `${BEARER_TOKEN_PREFIX}${shutdownToken}`,
-        },
-      },
-      timeoutMs,
-    );
+  private requestLocalShutdown(runtime: RuntimeStateRecord): void {
+    try {
+      process.kill(runtime.pid, 'SIGTERM');
+    } catch (error) {
+      if (isNodeError(error) && error.code === 'ESRCH') {
+        throw new Error(
+          `Runtime '${runtime.serverId}' is not running anymore (pid ${runtime.pid} does not exist).`,
+        );
+      }
 
-    const payload = (await response.json()) as unknown;
-    if (!isShutdownResponse(payload)) {
-      throw new Error('Received invalid shutdown response payload.');
+      if (isNodeError(error) && error.code === 'EPERM') {
+        throw new Error(
+          `Permission denied when signaling runtime '${runtime.serverId}' (pid ${runtime.pid}).`,
+        );
+      }
+
+      throw new Error(
+        `Failed to signal runtime '${runtime.serverId}' (pid ${runtime.pid}): ${toErrorMessage(error)}`,
+      );
     }
-
-    if (!response.ok || !payload.ok) {
-      throw new Error(payload.message);
-    }
-
-    return payload;
   }
 
   /**
@@ -276,4 +249,8 @@ export class StopServerService {
       clearTimeout(timeoutId);
     }
   }
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return typeof error === 'object' && error !== null && 'code' in error;
 }

--- a/packages/one-mcp/src/services/StopServerService/types.ts
+++ b/packages/one-mcp/src/services/StopServerService/types.ts
@@ -2,15 +2,10 @@
  * StopServerService types and type guards.
  */
 
-import type {
-  HttpTransportHealthResponse,
-  HttpTransportShutdownResponse,
-} from '../../types';
+import type { HttpTransportHealthResponse } from '../../types';
 import {
   HEALTH_STATUS_OK,
   HEALTH_TRANSPORT_HTTP,
-  KEY_MESSAGE,
-  KEY_OK,
   KEY_SERVER_ID,
   KEY_STATUS,
   KEY_TRANSPORT,
@@ -30,7 +25,6 @@ function toRecord(value: object): Record<string, unknown> {
  * @property serverId - Explicit one-mcp server identifier to stop
  * @property host - Host fallback for runtime lookup
  * @property port - Port fallback for runtime lookup
- * @property token - Optional shutdown token override
  * @property force - Skip server ID verification against /health when true
  * @property timeoutMs - Maximum time to wait for shutdown completion
  */
@@ -38,7 +32,6 @@ export interface StopServerRequest {
   serverId?: string;
   host?: string;
   port?: number;
-  token?: string;
   force?: boolean;
   timeoutMs?: number;
 }
@@ -84,27 +77,6 @@ export function isHealthResponse(value: unknown): value is HttpTransportHealthRe
     record[KEY_STATUS] === HEALTH_STATUS_OK &&
     KEY_TRANSPORT in record &&
     record[KEY_TRANSPORT] === HEALTH_TRANSPORT_HTTP &&
-    (!(KEY_SERVER_ID in record) ||
-      record[KEY_SERVER_ID] === undefined ||
-      typeof record[KEY_SERVER_ID] === 'string')
-  );
-}
-
-/**
- * Type guard for shutdown responses.
- * @param value - Candidate payload to validate
- * @returns True when payload matches shutdown response shape
- */
-export function isShutdownResponse(value: unknown): value is HttpTransportShutdownResponse {
-  if (typeof value !== 'object' || value === null) {
-    return false;
-  }
-  const record = toRecord(value);
-  return (
-    KEY_OK in record &&
-    typeof record[KEY_OK] === 'boolean' &&
-    KEY_MESSAGE in record &&
-    typeof record[KEY_MESSAGE] === 'string' &&
     (!(KEY_SERVER_ID in record) ||
       record[KEY_SERVER_ID] === undefined ||
       typeof record[KEY_SERVER_ID] === 'string')

--- a/packages/one-mcp/src/transports/http.ts
+++ b/packages/one-mcp/src/transports/http.ts
@@ -50,6 +50,7 @@ interface HttpSession {
  */
 class HttpFullSessionManager {
   private sessions: Map<string, HttpSession> = new Map();
+  private closingSessions: Set<string> = new Set();
 
   getSession(sessionId: string): HttpSession | undefined {
     return this.sessions.get(sessionId);
@@ -60,15 +61,25 @@ class HttpFullSessionManager {
   }
 
   async deleteSession(sessionId: string): Promise<void> {
-    const session = this.sessions.get(sessionId);
-    if (session) {
-      try {
-        await session.server.close();
-      } catch (error) {
-        throw new Error(`Failed to close MCP server for session '${sessionId}': ${toErrorMessage(error)}`);
-      }
+    if (this.closingSessions.has(sessionId)) {
+      return;
     }
+
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      return;
+    }
+
+    this.closingSessions.add(sessionId);
     this.sessions.delete(sessionId);
+
+    try {
+      await session.server.close();
+    } catch (error) {
+      throw new Error(`Failed to close MCP server for session '${sessionId}': ${toErrorMessage(error)}`);
+    } finally {
+      this.closingSessions.delete(sessionId);
+    }
   }
 
   hasSession(sessionId: string): boolean {
@@ -76,16 +87,23 @@ class HttpFullSessionManager {
   }
 
   async clear(): Promise<void> {
+    const sessions = Array.from(this.sessions.entries());
+    this.sessions.clear();
+
     try {
       await Promise.all(
-        Array.from(this.sessions.values()).map(async (session) => {
+        sessions.map(async ([sessionId, session]) => {
+          this.closingSessions.add(sessionId);
           await session.server.close();
         }),
       );
     } catch (error) {
       throw new Error(`Failed to clear sessions: ${toErrorMessage(error)}`);
+    } finally {
+      for (const [sessionId] of sessions) {
+        this.closingSessions.delete(sessionId);
+      }
     }
-    this.sessions.clear();
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,10 @@ overrides:
   rollup: 4.60.1
   express-rate-limit: 8.3.2
   liquidjs: 10.25.5
+  follow-redirects: 1.16.0
+  path-to-regexp: 8.4.0
+  yaml@1: 1.10.3
+  yaml@>=2: 2.8.3
 
 importers:
 
@@ -28,7 +32,7 @@ importers:
         version: 22.6.5(@babel/traverse@7.29.0)(nx@22.6.5)
       '@nx/vitest':
         specifier: 22.6.5
-        version: 22.6.5(@babel/traverse@7.29.0)(nx@22.6.5)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.4)
+        version: 22.6.5(@babel/traverse@7.29.0)(nx@22.6.5)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
       '@nx/workspace':
         specifier: 22.6.5
         version: 22.6.5
@@ -43,7 +47,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.1.4
-        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.11
@@ -178,7 +182,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.1.4
-        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/architect-mcp:
     dependencies:
@@ -236,7 +240,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.1.4
-        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/coding-agent-bridge:
     dependencies:
@@ -267,7 +271,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.1.4
-        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/hooks-adapter:
     dependencies:
@@ -295,7 +299,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.1.4
-        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/one-mcp:
     dependencies:
@@ -347,7 +351,7 @@ importers:
         version: 0.7.0(esbuild@0.28.0)
       vitest:
         specifier: 4.1.4
-        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/scaffold-mcp:
     dependencies:
@@ -435,7 +439,7 @@ importers:
         version: 8.6.18(storybook@8.6.18)
       '@tailwindcss/vite':
         specifier: 4.2.2
-        version: 4.2.2(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.2.2(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       chalk:
         specifier: 5.6.2
         version: 5.6.2
@@ -471,10 +475,10 @@ importers:
         version: 4.2.2
       vite:
         specifier: 8.0.8
-        version: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-plugin-singlefile:
         specifier: 2.3.2
-        version: 2.3.2(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 2.3.2(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     devDependencies:
       '@babel/parser':
         specifier: 7.29.2
@@ -514,7 +518,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.1.4
-        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 
@@ -3271,8 +3275,8 @@ packages:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
     hasBin: true
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -3924,8 +3928,8 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+  path-to-regexp@8.4.0:
+    resolution: {integrity: sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -4582,7 +4586,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: 2.8.3
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -4703,12 +4707,12 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
-  yaml@1.10.2:
-    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+  yaml@1.10.3:
+    resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
     engines: {node: '>= 6'}
 
-  yaml@2.8.2:
-    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -6300,7 +6304,7 @@ snapshots:
   '@nx/nx-win32-x64-msvc@22.6.5':
     optional: true
 
-  '@nx/vitest@22.6.5(@babel/traverse@7.29.0)(nx@22.6.5)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.4)':
+  '@nx/vitest@22.6.5(@babel/traverse@7.29.0)(nx@22.6.5)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)':
     dependencies:
       '@nx/devkit': 22.6.5(nx@22.6.5)
       '@nx/js': 22.6.5(@babel/traverse@7.29.0)(nx@22.6.5)
@@ -6308,8 +6312,8 @@ snapshots:
       semver: 7.7.4
       tslib: 2.8.1
     optionalDependencies:
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
-      vitest: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -6578,12 +6582,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
 
-  '@tailwindcss/vite@4.2.2(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@tailwindcss/vite@4.2.2(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -6686,7 +6690,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -6697,13 +6701,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.4':
     dependencies:
@@ -6812,7 +6816,7 @@ snapshots:
 
   axios@1.15.0:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -7050,7 +7054,7 @@ snapshots:
       import-fresh: 3.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
-      yaml: 1.10.2
+      yaml: 1.10.3
 
   cosmiconfig@9.0.1(typescript@5.9.3):
     dependencies:
@@ -7396,7 +7400,7 @@ snapshots:
 
   flat@5.0.2: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   for-each@0.3.5:
     dependencies:
@@ -7888,7 +7892,7 @@ snapshots:
       tree-kill: 1.2.2
       tsconfig-paths: 4.2.0
       tslib: 2.8.1
-      yaml: 2.8.2
+      yaml: 2.8.3
       yargs: 17.7.2
       yargs-parser: 21.1.1
     optionalDependencies:
@@ -7995,7 +7999,7 @@ snapshots:
       lru-cache: 11.2.4
       minipass: 7.1.3
 
-  path-to-regexp@8.3.0: {}
+  path-to-regexp@8.4.0: {}
 
   path-type@4.0.0: {}
 
@@ -8256,7 +8260,7 @@ snapshots:
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8669,13 +8673,13 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-plugin-singlefile@2.3.2(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vite-plugin-singlefile@2.3.2(rollup@4.60.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       micromatch: 4.0.8
       rollup: 4.60.1
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
-  vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2):
+  vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -8688,12 +8692,12 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       tsx: 4.21.0
-      yaml: 2.8.2
+      yaml: 2.8.3
 
-  vitest@4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vitest@4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -8710,7 +8714,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0
@@ -8765,9 +8769,9 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yaml@1.10.2: {}
+  yaml@1.10.3: {}
 
-  yaml@2.8.2: {}
+  yaml@2.8.3: {}
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
## Summary
- pin vulnerable transitive dependencies to clear the remaining Dependabot alerts
- change one-mcp stop to use local process signaling instead of reading a persisted shutdown token and forwarding it over HTTP
- fix recursive HTTP session cleanup in one-mcp that could trigger a RangeError during transport shutdown
- correct architect-mcp Nx project wiring so lint, typecheck, and test target the right package

## Verification
- pnpm install
- pnpm build
- pnpm lint
- pnpm typecheck
- pnpm test
- manual CLI validation: started one-mcp over HTTP, checked /health, ran one-mcp stop, confirmed the process exited cleanly