### PR TITLE
fix: align cli metadata and sync success output

### DIFF
--- a/apps/aicode-toolkit/src/commands/sync.ts
+++ b/apps/aicode-toolkit/src/commands/sync.ts
@@ -261,7 +261,7 @@ const METHOD_TO_EVENT: Record<string, string> = {
   taskCompleted: 'TaskCompleted',
 };
 
-async function writeClaudeSettings(config: ToolkitConfig, workspaceRoot: string): Promise<void> {
+async function writeClaudeSettings(config: ToolkitConfig, workspaceRoot: string): Promise<boolean> {
   try {
     const mcpConfigYaml = await readMcpConfigYaml(workspaceRoot);
     const mcpServers = mcpConfigYaml.mcpServers ?? {};
@@ -310,7 +310,7 @@ async function writeClaudeSettings(config: ToolkitConfig, workspaceRoot: string)
       print.warning(
         'No scaffold-mcp/architect-mcp hook.claude-code config found — skipping .claude/settings.json',
       );
-      return;
+      return false;
     }
 
     const settings: ClaudeSettingsJson = { hooks: hooksOutput };
@@ -321,20 +321,21 @@ async function writeClaudeSettings(config: ToolkitConfig, workspaceRoot: string)
       JSON.stringify(settings, null, 2),
       'utf-8',
     );
+    return true;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     throw new Error(`Failed to write ${CLAUDE_SETTINGS_DIR}/${CLAUDE_SETTINGS_FILE}: ${message}`);
   }
 }
 
-async function writeMcpConfig(config: ToolkitConfig, workspaceRoot: string): Promise<void> {
+async function writeMcpConfig(config: ToolkitConfig, workspaceRoot: string): Promise<boolean> {
   try {
     const mcpConfig = buildMcpConfigYaml(config);
     if (!mcpConfig) {
       print.warning(
         'No mcp-config.servers or mcp-config.skills config found — skipping mcp-config.yaml',
       );
-      return;
+      return false;
     }
 
     await writeFile(
@@ -342,6 +343,7 @@ async function writeMcpConfig(config: ToolkitConfig, workspaceRoot: string): Pro
       yaml.dump(mcpConfig, { indent: 2 }),
       'utf-8',
     );
+    return true;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     throw new Error(`Failed to write ${MCP_CONFIG_FILE}: ${message}`);
@@ -377,8 +379,9 @@ export const syncCommand = new Command('sync')
 
       if (shouldWriteHooks) {
         if (hasHookConfig(config)) {
-          await writeClaudeSettings(config, workspaceRoot);
-          print.success('Written .claude/settings.json');
+          if (await writeClaudeSettings(config, workspaceRoot)) {
+            print.success('Written .claude/settings.json');
+          }
         } else {
           print.warning('No hook.claude-code config found in toolkit settings — skipping');
         }
@@ -387,8 +390,9 @@ export const syncCommand = new Command('sync')
       if (shouldWriteMcp) {
         const mcpConfig = buildMcpConfigYaml(config);
         if (mcpConfig) {
-          await writeMcpConfig(config, workspaceRoot);
-          print.success('Written mcp-config.yaml');
+          if (await writeMcpConfig(config, workspaceRoot)) {
+            print.success('Written mcp-config.yaml');
+          }
         } else {
           print.warning(
             'No mcp-config.servers or mcp-config.skills config found — skipping mcp-config.yaml',

--- a/packages/style-system/src/cli.ts
+++ b/packages/style-system/src/cli.ts
@@ -24,6 +24,7 @@ import { getUiComponentCommand } from './commands/get-ui-component';
 import { listAppComponentsCommand } from './commands/list-app-components';
 import { listThemesCommand } from './commands/list-themes';
 import { listSharedComponentsCommand } from './commands/list-shared-components';
+import { STYLE_SYSTEM_CLI_NAME, STYLE_SYSTEM_VERSION } from './metadata';
 import { mcpServeCommand } from './commands/mcp-serve';
 
 /**
@@ -33,9 +34,9 @@ async function main() {
   const program = new Command();
 
   program
-    .name('style-system-mcp')
+    .name(STYLE_SYSTEM_CLI_NAME)
     .description('MCP server for design system tools')
-    .version('0.1.0');
+    .version(STYLE_SYSTEM_VERSION);
 
   // Add all commands
   program.addCommand(getCSSClassesCommand);

--- a/packages/style-system/src/commands/get-css-classes.ts
+++ b/packages/style-system/src/commands/get-css-classes.ts
@@ -9,7 +9,7 @@ import { GetCSSClassesTool } from '../tools/GetCSSClassesTool';
 interface GetCSSClassesOptions {
   category: string;
   appPath?: string;
-  themePath: string;
+  themePath?: string;
 }
 
 export const getCSSClassesCommand = new Command('get-css-classes')
@@ -25,8 +25,7 @@ export const getCSSClassesCommand = new Command('get-css-classes')
   )
   .option(
     '-t, --theme-path <path>',
-    'Default theme CSS file path relative to workspace root (used if appPath not provided or themePath not in project.json)',
-    'packages/frontend/web-theme/src/agimon-theme.css',
+    'Theme CSS file path relative to workspace root (required unless appPath resolves style-system.themePath from project.json)',
   )
   .action(async (options: GetCSSClassesOptions): Promise<void> => {
     try {

--- a/packages/style-system/src/commands/mcp-serve.ts
+++ b/packages/style-system/src/commands/mcp-serve.ts
@@ -20,6 +20,7 @@
  */
 
 import { Command } from 'commander';
+import { STYLE_SYSTEM_CLI_NAME } from '../metadata';
 import { createServer } from '../server';
 import { type BaseBundlerService, getBundlerServiceFromConfig } from '../services';
 import { StdioTransportHandler } from '../transports/stdio';
@@ -62,8 +63,7 @@ export const mcpServeCommand = new Command('mcp-serve')
   .option('-t, --type <type>', 'Transport type: stdio', 'stdio')
   .option(
     '--theme-path <path>',
-    'Default theme CSS file path relative to workspace root',
-    'packages/frontend/web-theme/src/agimon-theme.css',
+    'Theme CSS file path relative to workspace root for get-css-classes when app config does not define style-system.themePath',
   )
   .option('--dev', 'Start Vite dev server for component hot reload and caching')
   .option('--app-path <path>', 'App path for dev server (e.g., apps/agiflow-app)')
@@ -78,7 +78,7 @@ export const mcpServeCommand = new Command('mcp-serve')
       if (options.dev) {
         if (!options.appPath) {
           console.error('Error: --app-path is required when using --dev flag');
-          console.error('Example: style-system-mcp mcp-serve --dev --app-path apps/agiflow-app');
+          console.error(`Example: ${STYLE_SYSTEM_CLI_NAME} mcp-serve --dev --app-path apps/agiflow-app`);
           process.exit(1);
         }
 

--- a/packages/style-system/src/index.ts
+++ b/packages/style-system/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * style-system-mcp - Public API
+ * style-system - Public API
  *
  * DESIGN PATTERNS:
  * - Barrel export pattern for clean public API

--- a/packages/style-system/src/metadata.ts
+++ b/packages/style-system/src/metadata.ts
@@ -1,0 +1,5 @@
+import packageJson from '../package.json' assert { type: 'json' };
+
+export const STYLE_SYSTEM_CLI_NAME = 'style-system';
+export const STYLE_SYSTEM_SERVER_NAME = 'style-system';
+export const STYLE_SYSTEM_VERSION = packageJson.version;

--- a/packages/style-system/src/server/index.ts
+++ b/packages/style-system/src/server/index.ts
@@ -22,6 +22,7 @@ import {
   ListSharedComponentsTool,
   ListThemesTool,
 } from '../tools';
+import { STYLE_SYSTEM_SERVER_NAME, STYLE_SYSTEM_VERSION } from '../metadata';
 import type { ToolDefinition } from '../types';
 
 const TOOL_CAPABILITIES_META_KEY = 'agiflowai/capabilities';
@@ -36,11 +37,11 @@ function withCapabilities(definition: ToolDefinition, capabilities: string[]): T
   };
 }
 
-export function createServer(themePath = 'packages/frontend/web-theme/src/agimon-theme.css'): Server {
+export function createServer(themePath?: string): Server {
   const server = new Server(
     {
-      name: 'style-system-mcp',
-      version: '0.1.0',
+      name: STYLE_SYSTEM_SERVER_NAME,
+      version: STYLE_SYSTEM_VERSION,
     },
     {
       capabilities: {

--- a/packages/style-system/src/tools/GetCSSClassesTool.ts
+++ b/packages/style-system/src/tools/GetCSSClassesTool.ts
@@ -68,13 +68,13 @@ export class GetCSSClassesTool implements Tool<GetCSSClassesInput> {
 
   private serviceFactory: CSSClassesServiceFactory;
   private service: BaseCSSClassesService | null = null;
-  private defaultThemePath: string;
+  private defaultThemePath?: string;
 
   /**
    * Creates a new GetCSSClassesTool instance
    * @param defaultThemePath - Default path to theme CSS file (relative to workspace root)
    */
-  constructor(defaultThemePath: string = 'packages/frontend/web-theme/src/agimon-theme.css') {
+  constructor(defaultThemePath?: string) {
     this.serviceFactory = new CSSClassesServiceFactory();
     this.defaultThemePath = defaultThemePath;
   }
@@ -184,7 +184,12 @@ export class GetCSSClassesTool implements Tool<GetCSSClassesInput> {
       }
     }
 
-    // Use default theme path (relative to workspace root)
-    return path.resolve(workspaceRoot, this.defaultThemePath);
+    if (this.defaultThemePath) {
+      return path.resolve(workspaceRoot, this.defaultThemePath);
+    }
+
+    throw new Error(
+      'No theme CSS path configured. Pass --theme-path, or provide style-system.themePath in the target app project.json.',
+    );
   }
 }

--- a/packages/style-system/src/transports/stdio.ts
+++ b/packages/style-system/src/transports/stdio.ts
@@ -18,6 +18,7 @@
 import { log } from '@agiflowai/aicode-utils';
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { STYLE_SYSTEM_SERVER_NAME } from '../metadata';
 
 /**
  * Stdio transport handler for MCP server
@@ -34,7 +35,7 @@ export class StdioTransportHandler {
   async start(): Promise<void> {
     this.transport = new StdioServerTransport();
     await this.server.connect(this.transport);
-    log.info('style-system-mcp MCP server started on stdio');
+    log.info(`${STYLE_SYSTEM_SERVER_NAME} MCP server started on stdio`);
   }
 
   async stop(): Promise<void> {


### PR DESCRIPTION
## Summary
- align style-system CLI and server metadata with package metadata instead of hardcoded stale values
- require an explicit theme path or app style-system.themePath for style-system CSS extraction instead of pointing at a missing default file
- only print aicode sync success messages when files are actually written

## Validation
- pnpm install
- pnpm build
- pnpm test
- pnpm typecheck
- pnpm lint

## Notes
- pnpm test initially failed in the sandbox because one-mcp HTTP concurrency tests could not bind localhost ports; rerunning outside the sandbox passed cleanly
- pnpm lint completed successfully with existing Biome warnings in architect-mcp