### PR TITLE
fix(aicode-toolkit): handle init CJS interop

### DIFF
--- a/apps/aicode-toolkit/src/commands/init.ts
+++ b/apps/aicode-toolkit/src/commands/init.ts
@@ -10,7 +10,7 @@ import {
 import { confirm, input, select } from '@inquirer/prompts';
 import { Command } from 'commander';
 import { Liquid } from 'liquidjs';
-import ora from 'ora';
+import * as oraImport from 'ora';
 import { createActor, fromPromise } from 'xstate';
 import settingsLiquidTemplate from '../templates/settings.yaml.liquid?raw';
 import { MCP_SERVER_INFO, MCPServer } from '../constants';
@@ -24,7 +24,28 @@ import {
   TemplateSelectionService,
 } from '../services';
 import { type InitMachineInput, initMachine } from '../states/init-machine';
-import { displayBanner } from '../utils';
+import { displayBanner, displaySuccessMessage } from '../utils';
+
+type OraCreator = typeof import('ora').default;
+
+export function resolveOra(value: unknown, depth: number = 0): OraCreator {
+  if (typeof value === 'function') {
+    return value as OraCreator;
+  }
+
+  if (
+    depth < 3 &&
+    value &&
+    (typeof value === 'object' || typeof value === 'function') &&
+    'default' in value
+  ) {
+    return resolveOra((value as { default: unknown }).default, depth + 1);
+  }
+
+  throw new Error('Unable to resolve ora instance');
+}
+
+const ora = resolveOra(oraImport);
 
 const DEFAULT_TEMPLATE_REPO = {
   owner: 'AgiFlow',
@@ -874,11 +895,8 @@ export const initCommand = new Command('init')
       }
 
       // Display congratulations message with gradient
-      const gradient = await import('gradient-string');
       print.newline();
-      console.log(
-        gradient.default.pastel.multiline('🎉 Congratulations! Your project is ready to go!'),
-      );
+      displaySuccessMessage('🎉 Congratulations! Your project is ready to go!');
       print.newline();
     } catch (error) {
       print.error(`\nError: ${(error as Error).message}`);

--- a/apps/aicode-toolkit/src/services/CodingAgentService.ts
+++ b/apps/aicode-toolkit/src/services/CodingAgentService.ts
@@ -320,7 +320,7 @@ export class CodingAgentService {
    * @param selectedMcpServers - Array of selected MCP servers
    */
   private async createMcpConfigYaml(selectedMcpServers?: string[]): Promise<void> {
-    const { execSync } = await import('node:child_process');
+    const { execFileSync } = await import('node:child_process');
     const path = await import('node:path');
 
     // Build the MCP server configurations for included servers (excluding one-mcp)
@@ -357,13 +357,26 @@ export class CodingAgentService {
 
     const configPath = path.join(this.workspaceRoot, 'mcp-config.yaml');
 
-    // Build the command with optional --mcp-servers argument
     const mcpServersJson = JSON.stringify(servers);
-    const command = `npx -y @agiflowai/one-mcp init -o "${configPath}" -f --mcp-servers '${mcpServersJson}'`;
 
-    execSync(command, {
-      cwd: this.workspaceRoot,
-      stdio: 'inherit',
-    });
+    execFileSync(
+      'npx',
+      [
+        '--yes',
+        '--package',
+        '@agiflowai/one-mcp',
+        'one-mcp',
+        'init',
+        '-o',
+        configPath,
+        '-f',
+        '--mcp-servers',
+        mcpServersJson,
+      ],
+      {
+        cwd: this.workspaceRoot,
+        stdio: 'inherit',
+      },
+    );
   }
 }

--- a/apps/aicode-toolkit/src/utils/banner.ts
+++ b/apps/aicode-toolkit/src/utils/banner.ts
@@ -1,6 +1,8 @@
 import * as chalkImport from 'chalk';
-import gradient from 'gradient-string';
+import * as gradientImport from 'gradient-string';
 import { BANNER_GRADIENT } from '../constants';
+
+type GradientCreator = typeof import('gradient-string').default;
 
 function resolveChalk(value: unknown, depth: number = 0): typeof import('chalk').default {
   if (
@@ -25,6 +27,25 @@ function resolveChalk(value: unknown, depth: number = 0): typeof import('chalk')
 }
 
 const chalk = resolveChalk(chalkImport);
+
+export function resolveGradient(value: unknown, depth: number = 0): GradientCreator {
+  if (typeof value === 'function') {
+    return value as GradientCreator;
+  }
+
+  if (
+    depth < 3 &&
+    value &&
+    (typeof value === 'object' || typeof value === 'function') &&
+    'default' in value
+  ) {
+    return resolveGradient((value as { default: unknown }).default, depth + 1);
+  }
+
+  throw new Error('Unable to resolve gradient-string instance');
+}
+
+const gradient = resolveGradient(gradientImport);
 
 /**
  * ASCII art for AICode Toolkit - simple and highly readable design
@@ -70,4 +91,8 @@ export function displayCompactBanner(): void {
   console.log(chalk.bold('▸ ') + titleGradient('AICode Toolkit') + chalk.dim(' v0.6.0'));
   console.log(chalk.dim('  AI-Powered Code Toolkit'));
   console.log();
+}
+
+export function displaySuccessMessage(message: string): void {
+  console.log(gradient.pastel.multiline(message));
 }

--- a/apps/aicode-toolkit/src/utils/index.ts
+++ b/apps/aicode-toolkit/src/utils/index.ts
@@ -3,4 +3,4 @@
  */
 
 // Banner utilities
-export { displayBanner, displayCompactBanner } from './banner';
+export { displayBanner, displayCompactBanner, displaySuccessMessage } from './banner';

--- a/apps/aicode-toolkit/tests/commands/init.test.ts
+++ b/apps/aicode-toolkit/tests/commands/init.test.ts
@@ -1,5 +1,29 @@
 import { describe, expect, it } from 'vitest';
-import { resolveGeneratedSettingsValues } from '../../src/commands/init';
+import { resolveGeneratedSettingsValues, resolveOra } from '../../src/commands/init';
+
+function createOra() {
+  return () => ({
+    start: () => undefined,
+  });
+}
+
+describe('resolveOra', () => {
+  it('resolves direct ora exports', () => {
+    const ora = createOra();
+
+    expect(resolveOra(ora)).toBe(ora);
+  });
+
+  it('resolves nested default exports from CJS wrappers around ESM modules', () => {
+    const ora = createOra();
+
+    expect(resolveOra({ default: { default: ora } })).toBe(ora);
+  });
+
+  it('throws when no ora function can be resolved', () => {
+    expect(() => resolveOra({ default: {} })).toThrow('Unable to resolve ora instance');
+  });
+});
 
 describe('resolveGeneratedSettingsValues', () => {
   it('defaults templatesPath to templates when init skips template setup', () => {

--- a/apps/aicode-toolkit/tests/services/CodingAgentService.test.ts
+++ b/apps/aicode-toolkit/tests/services/CodingAgentService.test.ts
@@ -22,6 +22,7 @@ import {
   NONE,
 } from '@agiflowai/coding-agent-bridge';
 import * as fsHelpers from '@agiflowai/aicode-utils';
+import { execFileSync } from 'node:child_process';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CodingAgentService } from '../../src/services/CodingAgentService';
 
@@ -79,6 +80,10 @@ vi.mock('@agiflowai/coding-agent-bridge', () => {
   };
 });
 
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+}));
+
 describe('CodingAgentService', () => {
   const workspaceRoot = '/test/workspace';
   let service: CodingAgentService;
@@ -125,6 +130,40 @@ describe('CodingAgentService', () => {
       vi.mocked(fsHelpers.writeFile).mockResolvedValue(undefined);
 
       await expect(service.setupMCP(CLAUDE_CODE)).resolves.not.toThrow();
+    });
+
+    it('should create one-mcp config using explicit npx package execution', async () => {
+      vi.mocked(fsHelpers.pathExists).mockResolvedValue(false);
+      vi.mocked(fsHelpers.writeFile).mockResolvedValue(undefined);
+
+      await expect(
+        service.setupMCP(CLAUDE_CODE, ['one-mcp', 'architect-mcp']),
+      ).resolves.not.toThrow();
+
+      expect(execFileSync).toHaveBeenCalledWith(
+        'npx',
+        [
+          '--yes',
+          '--package',
+          '@agiflowai/one-mcp',
+          'one-mcp',
+          'init',
+          '-o',
+          '/test/workspace/mcp-config.yaml',
+          '-f',
+          '--mcp-servers',
+          JSON.stringify({
+            'architect-mcp': {
+              command: 'npx',
+              args: ['-y', '@agiflowai/architect-mcp', 'mcp-serve', '--admin-enable'],
+            },
+          }),
+        ],
+        {
+          cwd: workspaceRoot,
+          stdio: 'inherit',
+        },
+      );
     });
 
     it('should setup MCP for Codex', async () => {

--- a/apps/aicode-toolkit/tests/utils/banner.test.ts
+++ b/apps/aicode-toolkit/tests/utils/banner.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { resolveGradient } from '../../src/utils/banner';
+
+function createGradient() {
+  return Object.assign(() => 'gradient text', {
+    pastel: Object.assign((text: string) => text, {
+      multiline: (text: string) => text,
+    }),
+  });
+}
+
+describe('resolveGradient', () => {
+  it('resolves direct gradient-string exports', () => {
+    const gradient = createGradient();
+
+    expect(resolveGradient(gradient)).toBe(gradient);
+  });
+
+  it('resolves nested default exports from CJS wrappers around ESM modules', () => {
+    const gradient = createGradient();
+
+    expect(resolveGradient({ default: { default: gradient } })).toBe(gradient);
+  });
+
+  it('throws when no gradient-string function can be resolved', () => {
+    expect(() => resolveGradient({ default: {} })).toThrow(
+      'Unable to resolve gradient-string instance',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- resolve gradient-string and ora through CJS/ESM wrapper shapes before calling them from the CJS CLI bundle
- route init success messaging through the banner utility
- invoke one-mcp init via explicit npx --package argument execution to avoid nested scoped-package command resolution failures

Fixes #95.

## Verification
- biome check on touched files
- tsc -p apps/aicode-toolkit/tsconfig.json --noEmit
- ../../node_modules/.bin/vitest --run from apps/aicode-toolkit: 8 files, 74 tests passed
- ./node_modules/.bin/tsdown from apps/aicode-toolkit
- pre-commit nx run-many -t test: target test passed for 8 projects
- fresh /private/tmp formatjs clone: pnpm install, then npx local packed @agiflowai/aicode-toolkit aicode init completed successfully with default prompts