### PR TITLE
fix: resolve dependabot security alerts

### DIFF
--- a/apps/aicode-toolkit/package.json
+++ b/apps/aicode-toolkit/package.json
@@ -52,7 +52,7 @@
     "express": "5.2.1",
     "gradient-string": "3.0.0",
     "js-yaml": "4.1.1",
-    "liquidjs": "10.25.5",
+    "liquidjs": "10.25.7",
     "ora": "9.3.0",
     "pino": "10.3.1",
     "pino-pretty": "13.1.3",

--- a/package.json
+++ b/package.json
@@ -32,26 +32,5 @@
     "@commitlint/prompt-cli": "20.5.0",
     "husky": "9.1.7",
     "syncpack": "14.3.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "qs": "6.15.1",
-      "hono": "4.12.12",
-      "@hono/node-server": "1.19.14",
-      "axios": "1.15.0",
-      "ajv": "8.18.0",
-      "tar": "7.5.13",
-      "fast-xml-parser": "5.5.12",
-      "markdown-it": "14.1.1",
-      "@isaacs/brace-expansion": "5.0.1",
-      "minimatch": "10.2.5",
-      "rollup": "4.60.1",
-      "express-rate-limit": "8.3.2",
-      "liquidjs": "10.25.5",
-      "follow-redirects": "1.16.0",
-      "path-to-regexp": "8.4.0",
-      "yaml@1": "1.10.3",
-      "yaml@>=2": "2.8.3"
-    }
   }
 }

--- a/packages/architect-mcp/package.json
+++ b/packages/architect-mcp/package.json
@@ -36,7 +36,7 @@
     "express": "5.2.1",
     "js-yaml": "4.1.1",
     "minimatch": "10.2.5",
-    "uuid": "13.0.0",
+    "uuid": "13.0.1",
     "zod": "4.3.6"
   },
   "devDependencies": {

--- a/packages/coding-agent-bridge/package.json
+++ b/packages/coding-agent-bridge/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@agiflowai/aicode-utils": "workspace:*",
     "execa": "9.6.1",
-    "uuid": "13.0.0"
+    "uuid": "13.0.1"
   },
   "devDependencies": {
     "@types/node": "25.6.0",

--- a/packages/one-mcp/package.json
+++ b/packages/one-mcp/package.json
@@ -32,7 +32,7 @@
     "express": "5.2.1",
     "gray-matter": "4.0.3",
     "js-yaml": "4.1.1",
-    "liquidjs": "10.25.5",
+    "liquidjs": "10.25.7",
     "zod": "4.3.6"
   },
   "devDependencies": {

--- a/packages/scaffold-mcp/package.json
+++ b/packages/scaffold-mcp/package.json
@@ -53,7 +53,7 @@
     "execa": "9.6.1",
     "express": "5.2.1",
     "js-yaml": "4.1.1",
-    "liquidjs": "10.25.5",
+    "liquidjs": "10.25.7",
     "minimatch": "10.2.5",
     "pino": "10.3.1",
     "pino-pretty": "13.1.3",

--- a/packages/style-system/package.json
+++ b/packages/style-system/package.json
@@ -37,7 +37,7 @@
     "glob": "13.0.6",
     "js-yaml": "4.1.1",
     "playwright": "1.59.1",
-    "postcss": "8.5.9",
+    "postcss": "8.5.10",
     "react": "19.2.5",
     "react-dom": "19.2.5",
     "sharp": "0.34.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,21 +5,28 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  qs: 6.15.1
-  hono: 4.12.12
+  qs: 6.15.2
+  hono: 4.12.22
   '@hono/node-server': 1.19.14
-  axios: 1.15.0
+  axios: 1.15.2
   ajv: 8.18.0
   tar: 7.5.13
   fast-xml-parser: 5.5.12
   markdown-it: 14.1.1
   '@isaacs/brace-expansion': 5.0.1
+  brace-expansion: 5.0.6
   minimatch: 10.2.5
   rollup: 4.60.1
   express-rate-limit: 8.3.2
-  liquidjs: 10.25.5
+  liquidjs: 10.25.7
   follow-redirects: 1.16.0
   path-to-regexp: 8.4.0
+  fast-uri: 3.1.2
+  '@babel/plugin-transform-modules-systemjs': 7.29.4
+  ip-address: 10.1.1
+  postcss: 8.5.10
+  uuid: 13.0.1
+  ws: 8.20.1
   yaml@1: 1.10.3
   yaml@>=2: 2.8.3
 
@@ -104,8 +111,8 @@ importers:
         specifier: 4.1.1
         version: 4.1.1
       liquidjs:
-        specifier: 10.25.5
-        version: 10.25.5
+        specifier: 10.25.7
+        version: 10.25.7
       ora:
         specifier: 9.3.0
         version: 9.3.0
@@ -220,8 +227,8 @@ importers:
         specifier: 10.2.5
         version: 10.2.5
       uuid:
-        specifier: 13.0.0
-        version: 13.0.0
+        specifier: 13.0.1
+        version: 13.0.1
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -251,8 +258,8 @@ importers:
         specifier: 9.6.1
         version: 9.6.1
       uuid:
-        specifier: 13.0.0
-        version: 13.0.0
+        specifier: 13.0.1
+        version: 13.0.1
     devDependencies:
       '@types/node':
         specifier: 25.6.0
@@ -325,8 +332,8 @@ importers:
         specifier: 4.1.1
         version: 4.1.1
       liquidjs:
-        specifier: 10.25.5
-        version: 10.25.5
+        specifier: 10.25.7
+        version: 10.25.7
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -392,8 +399,8 @@ importers:
         specifier: 4.1.1
         version: 4.1.1
       liquidjs:
-        specifier: 10.25.5
-        version: 10.25.5
+        specifier: 10.25.7
+        version: 10.25.7
       minimatch:
         specifier: 10.2.5
         version: 10.2.5
@@ -456,8 +463,8 @@ importers:
         specifier: 1.59.1
         version: 1.59.1
       postcss:
-        specifier: 8.5.9
-        version: 8.5.9
+        specifier: 8.5.10
+        version: 8.5.10
       react:
         specifier: 19.2.5
         version: 19.2.5
@@ -883,8 +890,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-modules-systemjs@7.28.5':
-    resolution: {integrity: sha512-vn5Jma98LCOeBy/KpeQhXcV2WZgaRUtjwQmjoBuLNlOmkg0fB5pdvYVeWRYI69wWKwK2cD1QbMiUQnoujWvrew==}
+  '@babel/plugin-transform-modules-systemjs@7.29.4':
+    resolution: {integrity: sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1739,7 +1746,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: 4.12.12
+      hono: 4.12.22
 
   '@img/colour@1.0.0':
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
@@ -2761,8 +2768,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+  axios@1.15.2:
+    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
 
   babel-plugin-const-enum@1.2.0:
     resolution: {integrity: sha512-o1m/6iyyFnp9MRsK1dHF3bneqyf3AlM2q3A/YbgQr2pCat6B6XJVDv2TXqzfY2RYUi4mak6WAksSBPlyYGx9dg==}
@@ -2822,8 +2829,8 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -3240,8 +3247,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -3400,8 +3407,8 @@ packages:
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
-  hono@4.12.12:
-    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
+  hono@4.12.22:
+    resolution: {integrity: sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==}
     engines: {node: '>=16.9.0'}
 
   hookable@6.1.0:
@@ -3460,8 +3467,8 @@ packages:
     resolution: {integrity: sha512-pFGGdaHrmRKMh4WoDDSowddgjT1Vkl90atobmTeSmcPGdYiwikch/m/Ef5wRaiamHejtw0cUUMMerzDUXCci2w==}
     engines: {node: '>=18'}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.1.1:
+    resolution: {integrity: sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -3702,8 +3709,8 @@ packages:
     resolution: {integrity: sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  liquidjs@10.25.5:
-    resolution: {integrity: sha512-GKiKeZjJDdVoQAu+S9rzkYsYnYhcep5W3WwZXgb5f+yq484P/k9JqamBbGYu+LBEixcUAXZr2jogdAIjB3ki1w==}
+  liquidjs@10.25.7:
+    resolution: {integrity: sha512-rPCjJLiD4eDhQjvv964AeXFC+HbeYBbZrd7Z82Q6hqv1lX7G+5w4SJcKLn9CAAAwHI4aS3dTdo083UB79K3pDA==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -3986,8 +3993,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.9:
-    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   pretty-format@30.2.0:
@@ -4016,8 +4023,8 @@ packages:
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   quansync@1.0.0:
@@ -4555,8 +4562,8 @@ packages:
   util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
 
-  uuid@13.0.0:
-    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+  uuid@13.0.1:
+    resolution: {integrity: sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw==}
     hasBin: true
 
   vary@1.1.2:
@@ -4685,8 +4692,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.19.0:
-    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -5178,7 +5185,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.28.5(@babel/core@7.28.6)':
+  '@babel/plugin-transform-modules-systemjs@7.29.4(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.6)
@@ -5407,7 +5414,7 @@ snapshots:
       '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.28.6)
       '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.28.6)
       '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.28.6)
-      '@babel/plugin-transform-modules-systemjs': 7.28.5(@babel/core@7.28.6)
+      '@babel/plugin-transform-modules-systemjs': 7.29.4(@babel/core@7.28.6)
       '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.28.6)
       '@babel/plugin-transform-named-capturing-groups-regex': 7.27.1(@babel/core@7.28.6)
       '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.28.6)
@@ -5937,9 +5944,9 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
-  '@hono/node-server@1.19.14(hono@4.12.12)':
+  '@hono/node-server@1.19.14(hono@4.12.22)':
     dependencies:
-      hono: 4.12.12
+      hono: 4.12.22
 
   '@img/colour@1.0.0': {}
 
@@ -6194,7 +6201,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.12)
+      '@hono/node-server': 1.19.14(hono@4.12.22)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -6204,7 +6211,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.12
+      hono: 4.12.22
       jose: 6.1.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -6506,7 +6513,7 @@ snapshots:
       recast: 0.23.11
       semver: 7.7.4
       util: 0.12.5
-      ws: 8.19.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - storybook
@@ -6758,7 +6765,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6814,7 +6821,7 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.15.0:
+  axios@1.15.2:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5
@@ -6894,13 +6901,13 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.1
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -7314,7 +7321,7 @@ snapshots:
   express-rate-limit@8.3.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.1.1
 
   express@5.2.1:
     dependencies:
@@ -7338,7 +7345,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.1
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -7365,7 +7372,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:
@@ -7519,7 +7526,7 @@ snapshots:
 
   help-me@5.0.0: {}
 
-  hono@4.12.12: {}
+  hono@4.12.22: {}
 
   hookable@6.1.0: {}
 
@@ -7577,7 +7584,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  ip-address@10.1.0: {}
+  ip-address@10.1.1: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -7751,7 +7758,7 @@ snapshots:
 
   lines-and-columns@2.0.3: {}
 
-  liquidjs@10.25.5:
+  liquidjs@10.25.7:
     dependencies:
       commander: 10.0.1
 
@@ -7830,7 +7837,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimist@1.2.8: {}
 
@@ -7863,7 +7870,7 @@ snapshots:
       '@yarnpkg/lockfile': 1.1.0
       '@yarnpkg/parsers': 3.0.2
       '@zkochan/js-yaml': 0.0.7
-      axios: 1.15.0
+      axios: 1.15.2
       cli-cursor: 3.1.0
       cli-spinners: 2.6.1
       cliui: 8.0.1
@@ -8061,7 +8068,7 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.9:
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -8093,7 +8100,7 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
 
-  qs@6.15.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -8669,7 +8676,7 @@ snapshots:
       is-typed-array: 1.1.15
       which-typed-array: 1.1.20
 
-  uuid@13.0.0: {}
+  uuid@13.0.1: {}
 
   vary@1.1.2: {}
 
@@ -8683,7 +8690,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.9
+      postcss: 8.5.10
       rolldown: 1.0.0-rc.15
       tinyglobby: 0.2.16
     optionalDependencies:
@@ -8761,7 +8768,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.19.0: {}
+  ws@8.20.1: {}
 
   xstate@5.30.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,34 @@
 packages:
   - 'packages/*'
   - 'apps/*'
+
+allowBuilds:
+  esbuild: true
+  nx: true
+  sharp: true
+
+overrides:
+  qs: 6.15.2
+  hono: 4.12.22
+  '@hono/node-server': 1.19.14
+  axios: 1.15.2
+  ajv: 8.18.0
+  tar: 7.5.13
+  fast-xml-parser: 5.5.12
+  markdown-it: 14.1.1
+  '@isaacs/brace-expansion': 5.0.1
+  brace-expansion: 5.0.6
+  minimatch: 10.2.5
+  rollup: 4.60.1
+  express-rate-limit: 8.3.2
+  liquidjs: 10.25.7
+  follow-redirects: 1.16.0
+  path-to-regexp: 8.4.0
+  fast-uri: 3.1.2
+  '@babel/plugin-transform-modules-systemjs': 7.29.4
+  ip-address: 10.1.1
+  postcss: 8.5.10
+  uuid: 13.0.1
+  ws: 8.20.1
+  yaml@1: 1.10.3
+  yaml@>=2: 2.8.3


### PR DESCRIPTION
## Summary
- move pnpm overrides into pnpm-workspace.yaml so pnpm 11 applies them
- update vulnerable direct dependencies and lockfile resolutions
- approve required pnpm build scripts for existing build dependencies

## Validation
- pnpm install
- pnpm build
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm audit --audit-level moderate