### PR TITLE
feat(scaffold-mcp): add CLI parity for MCP tools

### DIFF
--- a/packages/scaffold-mcp/README.md
+++ b/packages/scaffold-mcp/README.md
@@ -121,6 +121,25 @@ npx @agiflowai/scaffold-mcp scaffold list ./apps/my-app
 npx @agiflowai/scaffold-mcp scaffold add scaffold-nextjs-page \
   --project ./apps/my-app \
   --vars '{"pageTitle":"About","nextjsPagePath":"/about"}'
+
+# Create template authoring entries (CLI equivalents for admin MCP tools)
+npx @agiflowai/scaffold-mcp boilerplate generate scaffold-vite-app \
+  --template vite-react \
+  --description "React Vite starter" \
+  --target-folder apps \
+  --variables '[{"name":"appName","description":"Application name","type":"string","required":true}]'
+
+npx @agiflowai/scaffold-mcp scaffold generate scaffold-service \
+  --template typescript-lib \
+  --description "Generate a service class and unit test" \
+  --variables '[{"name":"serviceName","description":"Service name","type":"string","required":true}]'
+
+npx @agiflowai/scaffold-mcp template file create src/index.ts \
+  --template typescript-lib \
+  --content 'export const {{ name | camelCase }} = "{{ name }}";'
+
+npx @agiflowai/scaffold-mcp file write .env.local \
+  --content 'NEXT_PUBLIC_API_URL=https://api.example.com'
 ```
 
 ---

--- a/packages/scaffold-mcp/docs/cli-commands.md
+++ b/packages/scaffold-mcp/docs/cli-commands.md
@@ -37,14 +37,16 @@ Create a new project from a boilerplate.
 ```bash
 npx @agiflowai/scaffold-mcp boilerplate create nextjs-15-drizzle \
   --vars '{"projectName":"my-app","packageName":"@myorg/my-app","appName":"My App"}' \
-  --target ./apps
+  --target-folder ./apps
 ```
 
 **Options:**
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--vars <json>` | Variables matching the boilerplate schema | Required |
-| `--target <path>` | Target directory | Current directory |
+| `--target-folder <path>` | Override target folder | Boilerplate target folder |
+| `--monolith` | Create as monolith project at workspace root | `false` |
+| `--marker <tag>` | Custom scaffold marker injected into generated code files | `@scaffold-generated` |
 
 **What happens:**
 1. Creates `<target>/<projectName>` directory
@@ -64,6 +66,8 @@ List available scaffold methods for a project.
 
 ```bash
 npx @agiflowai/scaffold-mcp scaffold list ./apps/my-app
+npx @agiflowai/scaffold-mcp scaffold list --template nextjs-15
+npx @agiflowai/scaffold-mcp scaffold list
 ```
 
 **How it works:**
@@ -72,7 +76,7 @@ npx @agiflowai/scaffold-mcp scaffold list ./apps/my-app
 3. Finds matching template and reads `scaffold.yaml`
 4. Lists all defined scaffold methods
 
-**Note:** Project must have a `project.json` with a `sourceTemplate` field.
+**Note:** When no project path or template is provided, the current working directory is used.
 
 ### `scaffold info <feature-name>`
 
@@ -107,6 +111,7 @@ npx @agiflowai/scaffold-mcp scaffold add scaffold-nextjs-page \
 |--------|-------------|
 | `--project <path>` | Path to the project (required) |
 | `--vars <json>` | Variables matching the method's schema (required) |
+| `--marker <tag>` | Custom scaffold marker injected into generated code files |
 
 **What happens:**
 1. Validates project has correct `sourceTemplate`
@@ -114,6 +119,86 @@ npx @agiflowai/scaffold-mcp scaffold add scaffold-nextjs-page \
 3. If custom generator exists, executes it
 4. Otherwise, copies and processes template files
 5. Returns created files and instructions
+
+---
+
+## Template Authoring Commands
+
+These commands provide CLI equivalents for scaffold-mcp admin MCP tools.
+
+### `boilerplate generate <name>`
+
+Create a boilerplate configuration in a template's `scaffold.yaml`.
+
+```bash
+npx @agiflowai/scaffold-mcp boilerplate generate scaffold-vite-app \
+  --template vite-react \
+  --description "React Vite starter" \
+  --target-folder apps \
+  --variables '[{"name":"appName","description":"Application name","type":"string","required":true}]' \
+  --include package.json \
+  --include src/main.tsx
+```
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--template <name>` | Template name; optional in monolith mode |
+| `--description <text>` / `--description-file <path>` | Boilerplate description |
+| `--instruction <text>` / `--instruction-file <path>` | Optional usage instructions |
+| `--target-folder <path>` | Target folder; defaults to `.` in monolith mode |
+| `--variables <json>` | JSON array of variable definitions |
+| `--include <path>` | Include path; repeat for multiple files |
+
+### `scaffold generate <name>`
+
+Create a feature scaffold configuration in a template's `scaffold.yaml`.
+
+```bash
+npx @agiflowai/scaffold-mcp scaffold generate scaffold-service \
+  --template typescript-lib \
+  --description "Generate a service class and unit test" \
+  --variables '[{"name":"serviceName","description":"Service name","type":"string","required":true}]' \
+  --include src/services/ExampleService.ts \
+  --pattern 'src/services/**/*.ts'
+```
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--template <name>` | Template name; optional in monolith mode |
+| `--description <text>` / `--description-file <path>` | Feature description |
+| `--instruction <text>` / `--instruction-file <path>` | Optional usage instructions |
+| `--variables <json>` | JSON array of variable definitions |
+| `--include <path>` | Include path; repeat for multiple files |
+| `--pattern <glob>` | Matching file pattern; repeat for multiple patterns |
+
+### `template file create <file-path>`
+
+Create or update a Liquid template file for boilerplates or features.
+
+```bash
+npx @agiflowai/scaffold-mcp template file create src/index.ts \
+  --template typescript-lib \
+  --content 'export const {{ name | camelCase }} = "{{ name }}";'
+```
+
+Use exactly one of `--content`, `--content-file`, or `--source-file`. The command writes `.liquid` files automatically.
+
+---
+
+## Utility Commands
+
+### `file write <file-path>`
+
+Write content to a file inside the current workspace.
+
+```bash
+npx @agiflowai/scaffold-mcp file write .env.local \
+  --content 'NEXT_PUBLIC_API_URL=https://api.example.com'
+```
+
+Use `--content-file <path>` to read content from an existing file.
 
 ---
 
@@ -126,7 +211,7 @@ npx @agiflowai/scaffold-mcp boilerplate list
 # 2. Create a new Next.js project
 npx @agiflowai/scaffold-mcp boilerplate create nextjs-15-drizzle \
   --vars '{"projectName":"my-app","packageName":"@myorg/my-app","appName":"My App"}' \
-  --target ./apps
+  --target-folder ./apps
 
 # 3. List available features
 npx @agiflowai/scaffold-mcp scaffold list ./apps/my-app

--- a/packages/scaffold-mcp/src/cli.ts
+++ b/packages/scaffold-mcp/src/cli.ts
@@ -2,9 +2,11 @@
 import { Command } from 'commander';
 import packageJson from '../package.json' assert { type: 'json' };
 import { boilerplateCommand } from './commands/boilerplate';
+import { fileCommand } from './commands/file';
 import { mcpServeCommand } from './commands/mcp-serve';
 import { scaffoldCommand } from './commands/scaffold';
 import { hookCommand } from './commands/hook';
+import { templateCommand } from './commands/template';
 
 /**
  * Main entry point
@@ -21,6 +23,8 @@ async function main() {
   program.addCommand(mcpServeCommand);
   program.addCommand(boilerplateCommand);
   program.addCommand(scaffoldCommand);
+  program.addCommand(templateCommand);
+  program.addCommand(fileCommand);
   program.addCommand(hookCommand);
 
   // Parse arguments

--- a/packages/scaffold-mcp/src/commands/boilerplate.ts
+++ b/packages/scaffold-mcp/src/commands/boilerplate.ts
@@ -1,6 +1,26 @@
 import { icons, messages, print, sections, TemplatesManagerService } from '@agiflowai/aicode-utils';
 import { Command } from 'commander';
 import { BoilerplateService } from '../services/BoilerplateService';
+import { GenerateBoilerplateTool } from '../tools';
+import {
+  assertToolSuccess,
+  collectOption,
+  detectMonolithMode,
+  loadTextOption,
+  parseJsonOption,
+  resolveTemplatesPath,
+} from './utils';
+
+interface GenerateBoilerplateOptions {
+  template?: string;
+  description?: string;
+  descriptionFile?: string;
+  instruction?: string;
+  instructionFile?: string;
+  targetFolder?: string;
+  variables?: string;
+  include?: string[];
+}
 
 /**
  * Boilerplate CLI command
@@ -77,6 +97,7 @@ boilerplateCommand
     '-t, --target-folder <path>',
     'Override target folder (defaults to boilerplate targetFolder for monorepo, workspace root for monolith)',
   )
+  .option('--marker <tag>', 'Custom scaffold marker tag to inject into generated code files')
   .option('--verbose', 'Enable verbose logging')
   .action(async (boilerplateName, options) => {
     try {
@@ -163,6 +184,7 @@ boilerplateCommand
         variables,
         monolith: options.monolith,
         targetFolderOverride: options.targetFolder,
+        marker: options.marker,
       });
 
       if (result.success) {
@@ -198,6 +220,78 @@ boilerplateCommand
       if (options.verbose) {
         console.error('Stack trace:', (error as Error).stack);
       }
+      process.exit(1);
+    }
+  });
+
+// Generate command
+boilerplateCommand
+  .command('generate <boilerplateName>')
+  .description("Create a new boilerplate configuration in a template's scaffold.yaml")
+  .option('-t, --template <name>', 'Template name (optional in monolith mode)')
+  .option('--description <text>', 'Boilerplate description')
+  .option('--description-file <path>', 'Read boilerplate description from a file')
+  .option('--instruction <text>', 'Detailed boilerplate instructions')
+  .option('--instruction-file <path>', 'Read detailed boilerplate instructions from a file')
+  .option('--target-folder <path>', 'Target folder for generated projects')
+  .option(
+    '--variables <json>',
+    'JSON array of variable definitions: [{"name":"appName","description":"App name","type":"string","required":true}]',
+  )
+  .option('-i, --include <path>', 'Template include path (repeatable)', collectOption, [])
+  .action(async (boilerplateName: string, options: GenerateBoilerplateOptions) => {
+    try {
+      const templatesPath = await resolveTemplatesPath();
+      const isMonolith = await detectMonolithMode();
+      const description = await loadTextOption({
+        value: options.description,
+        filePath: options.descriptionFile,
+        valueFlag: '--description',
+        fileFlag: '--description-file',
+        required: true,
+      });
+      const instruction = await loadTextOption({
+        value: options.instruction,
+        filePath: options.instructionFile,
+        valueFlag: '--instruction',
+        fileFlag: '--instruction-file',
+      });
+      const variables = parseJsonOption<
+        Array<{
+          name: string;
+          description: string;
+          type: string;
+          required: boolean;
+          default?: unknown;
+        }>
+      >(options.variables, '--variables');
+
+      if (!Array.isArray(variables)) {
+        throw new Error('--variables must be a JSON array');
+      }
+
+      const targetFolder = options.targetFolder ?? (isMonolith ? '.' : undefined);
+      if (!targetFolder) {
+        throw new Error('--target-folder is required outside monolith mode');
+      }
+
+      const tool = new GenerateBoilerplateTool(templatesPath, isMonolith);
+      const result = await tool.execute({
+        templateName: options.template,
+        boilerplateName,
+        description: description ?? '',
+        instruction,
+        targetFolder,
+        variables,
+        includes: options.include ?? [],
+      });
+
+      print.info(assertToolSuccess(result));
+    } catch (error) {
+      print.error(
+        'Error generating boilerplate:',
+        error instanceof Error ? error.message : String(error),
+      );
       process.exit(1);
     }
   });

--- a/packages/scaffold-mcp/src/commands/file.ts
+++ b/packages/scaffold-mcp/src/commands/file.ts
@@ -1,0 +1,39 @@
+import { print } from '@agiflowai/aicode-utils';
+import { Command } from 'commander';
+import { WriteToFileTool } from '../tools';
+import { assertToolSuccess, loadTextOption } from './utils';
+
+interface FileWriteOptions {
+  content?: string;
+  contentFile?: string;
+}
+
+export const fileCommand = new Command('file').description('Workspace file utilities');
+
+fileCommand
+  .command('write <filePath>')
+  .description('Write content to a file inside the current workspace')
+  .option('--content <text>', 'Content to write')
+  .option('--content-file <path>', 'Read content to write from a file')
+  .action(async (filePath: string, options: FileWriteOptions): Promise<void> => {
+    try {
+      const content = await loadTextOption({
+        value: options.content,
+        filePath: options.contentFile,
+        valueFlag: '--content',
+        fileFlag: '--content-file',
+        required: true,
+      });
+
+      const tool = new WriteToFileTool();
+      const result = await tool.execute({
+        file_path: filePath,
+        content,
+      });
+
+      print.info(assertToolSuccess(result));
+    } catch (error) {
+      print.error('Error writing file:', error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+  });

--- a/packages/scaffold-mcp/src/commands/scaffold.ts
+++ b/packages/scaffold-mcp/src/commands/scaffold.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import {
+  generateStableId,
   icons,
   messages,
   ProjectConfigResolver,
@@ -12,6 +13,27 @@ import {
   ScaffoldingMethodsService,
   type ListScaffoldingMethodsResult,
 } from '../services/ScaffoldingMethodsService';
+import { GenerateFeatureScaffoldTool } from '../tools';
+import { writePendingScaffoldLog } from '../utils/scaffoldPendingLog';
+import {
+  assertToolSuccess,
+  collectOption,
+  detectMonolithMode,
+  loadTextOption,
+  parseJsonOption,
+  resolveTemplatesPath,
+} from './utils';
+
+interface GenerateFeatureOptions {
+  template?: string;
+  description?: string;
+  descriptionFile?: string;
+  instruction?: string;
+  instructionFile?: string;
+  variables?: string;
+  include?: string[];
+  pattern?: string[];
+}
 
 /**
  * Scaffold CLI command
@@ -28,15 +50,6 @@ scaffoldCommand
   .option('-c, --cursor <cursor>', 'Pagination cursor for next page')
   .action(async (projectPath, options) => {
     try {
-      // Require either projectPath or template option
-      if (!projectPath && !options.template) {
-        messages.error('Either projectPath or --template option must be provided');
-        messages.hint('Examples:');
-        print.debug('  scaffold-mcp scaffold list ./my-project');
-        print.debug('  scaffold-mcp scaffold list --template nextjs-15');
-        process.exit(1);
-      }
-
       const templatesDir = await TemplatesManagerService.findTemplatesPath();
       if (!templatesDir) {
         messages.error(
@@ -53,9 +66,10 @@ scaffoldCommand
       let result: ListScaffoldingMethodsResult;
       let displayName: string;
 
-      if (projectPath) {
+      if (projectPath || !options.template) {
         // Use project path
-        const absolutePath = path.resolve(projectPath);
+        const inputProjectPath = projectPath ?? process.cwd();
+        const absolutePath = path.resolve(inputProjectPath);
 
         // Verify project configuration exists (supports both monolith and monorepo)
         const hasConfig = await ProjectConfigResolver.hasConfiguration(absolutePath);
@@ -73,7 +87,7 @@ scaffoldCommand
           absolutePath,
           options.cursor,
         );
-        displayName = projectPath;
+        displayName = projectPath ?? absolutePath;
       } else {
         // Use template name
         result = await scaffoldingMethodsService.listScaffoldingMethodsByTemplate(
@@ -129,6 +143,7 @@ scaffoldCommand
   .description('Add a feature to an existing project')
   .option('-p, --project <path>', 'Project path', process.cwd())
   .option('-v, --vars <json>', 'JSON string containing variables for the feature')
+  .option('--marker <tag>', 'Custom scaffold marker tag to inject into generated code files')
   .option('--verbose', 'Enable verbose logging')
   .action(async (featureName, options) => {
     try {
@@ -238,9 +253,20 @@ scaffoldCommand
         projectPath,
         scaffold_feature_name: featureName,
         variables,
+        marker: options.marker,
       });
 
       if (result.success) {
+        const scaffoldId = generateStableId(6);
+        if (result.createdFiles && result.createdFiles.length > 0) {
+          await writePendingScaffoldLog({
+            scaffoldId,
+            projectPath,
+            featureName,
+            generatedFiles: result.createdFiles,
+          });
+        }
+
         messages.success('✅ Feature added successfully!');
 
         if (result.createdFiles && result.createdFiles.length > 0) {
@@ -257,6 +283,8 @@ scaffoldCommand
           });
         }
 
+        print.debug(`\nSCAFFOLD_ID:${scaffoldId}`);
+
         print.header('\n📋 Next steps:');
         print.debug('   - Review the generated files');
         print.debug('   - Update imports if necessary');
@@ -267,6 +295,78 @@ scaffoldCommand
       }
     } catch (error) {
       messages.error(`❌ Error adding feature: ${(error as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+// Generate command
+scaffoldCommand
+  .command('generate <featureName>')
+  .description("Create a new feature scaffold configuration in a template's scaffold.yaml")
+  .option('-t, --template <name>', 'Template name (optional in monolith mode)')
+  .option('--description <text>', 'Feature description')
+  .option('--description-file <path>', 'Read feature description from a file')
+  .option('--instruction <text>', 'Detailed feature instructions')
+  .option('--instruction-file <path>', 'Read detailed feature instructions from a file')
+  .option(
+    '--variables <json>',
+    'JSON array of variable definitions: [{"name":"featureName","description":"Feature name","type":"string","required":true}]',
+  )
+  .option('-i, --include <path>', 'Template include path (repeatable)', collectOption, [])
+  .option(
+    '--pattern <glob>',
+    'File pattern this scaffold applies to (repeatable)',
+    collectOption,
+    [],
+  )
+  .action(async (featureName: string, options: GenerateFeatureOptions) => {
+    try {
+      const templatesPath = await resolveTemplatesPath();
+      const isMonolith = await detectMonolithMode();
+      const description = await loadTextOption({
+        value: options.description,
+        filePath: options.descriptionFile,
+        valueFlag: '--description',
+        fileFlag: '--description-file',
+        required: true,
+      });
+      const instruction = await loadTextOption({
+        value: options.instruction,
+        filePath: options.instructionFile,
+        valueFlag: '--instruction',
+        fileFlag: '--instruction-file',
+      });
+      const variables = parseJsonOption<
+        Array<{
+          name: string;
+          description: string;
+          type: string;
+          required: boolean;
+          default?: unknown;
+        }>
+      >(options.variables, '--variables');
+
+      if (!Array.isArray(variables)) {
+        throw new Error('--variables must be a JSON array');
+      }
+
+      const tool = new GenerateFeatureScaffoldTool(templatesPath, isMonolith);
+      const result = await tool.execute({
+        templateName: options.template,
+        featureName,
+        description: description ?? '',
+        instruction,
+        variables,
+        includes: options.include ?? [],
+        patterns: options.pattern ?? [],
+      });
+
+      print.info(assertToolSuccess(result));
+    } catch (error) {
+      print.error(
+        'Error generating feature scaffold:',
+        error instanceof Error ? error.message : String(error),
+      );
       process.exit(1);
     }
   });

--- a/packages/scaffold-mcp/src/commands/template.ts
+++ b/packages/scaffold-mcp/src/commands/template.ts
@@ -1,0 +1,81 @@
+import { print } from '@agiflowai/aicode-utils';
+import { Command } from 'commander';
+import { GenerateBoilerplateFileTool } from '../tools';
+import {
+  assertToolSuccess,
+  detectMonolithMode,
+  loadTextOption,
+  resolveTemplatesPath,
+} from './utils';
+
+interface TemplateFileCreateOptions {
+  template?: string;
+  content?: string;
+  contentFile?: string;
+  sourceFile?: string;
+  header?: string;
+  headerFile?: string;
+}
+
+export const templateCommand = new Command('template').description(
+  'Manage scaffold template authoring assets',
+);
+
+const fileCommand = new Command('file').description('Manage template files');
+
+fileCommand
+  .command('create <filePath>')
+  .description('Create or update a Liquid template file for a boilerplate or feature')
+  .option('-t, --template <name>', 'Template name (optional in monolith mode)')
+  .option('--content <text>', 'Template file content')
+  .option('--content-file <path>', 'Read template file content from a file')
+  .option('--source-file <path>', 'Copy content from an existing source file')
+  .option('--header <text>', 'Header comment to prepend to the template file')
+  .option('--header-file <path>', 'Read header comment from a file')
+  .action(async (filePath: string, options: TemplateFileCreateOptions): Promise<void> => {
+    try {
+      const contentInputs = [
+        options.content !== undefined,
+        options.contentFile !== undefined,
+        options.sourceFile !== undefined,
+      ].filter(Boolean).length;
+
+      if (contentInputs !== 1) {
+        throw new Error('Use exactly one of --content, --content-file, or --source-file');
+      }
+
+      const templatesPath = await resolveTemplatesPath();
+      const isMonolith = await detectMonolithMode();
+      const content = await loadTextOption({
+        value: options.content,
+        filePath: options.contentFile,
+        valueFlag: '--content',
+        fileFlag: '--content-file',
+      });
+      const header = await loadTextOption({
+        value: options.header,
+        filePath: options.headerFile,
+        valueFlag: '--header',
+        fileFlag: '--header-file',
+      });
+
+      const tool = new GenerateBoilerplateFileTool(templatesPath, isMonolith);
+      const result = await tool.execute({
+        templateName: options.template,
+        filePath,
+        content,
+        sourceFile: options.sourceFile,
+        header,
+      });
+
+      print.info(assertToolSuccess(result));
+    } catch (error) {
+      print.error(
+        'Error creating template file:',
+        error instanceof Error ? error.message : String(error),
+      );
+      process.exit(1);
+    }
+  });
+
+templateCommand.addCommand(fileCommand);

--- a/packages/scaffold-mcp/src/commands/utils.ts
+++ b/packages/scaffold-mcp/src/commands/utils.ts
@@ -1,0 +1,80 @@
+import { ProjectConfigResolver, TemplatesManagerService, readFile } from '@agiflowai/aicode-utils';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+export function parseJsonOption<T>(value: string | undefined, flagName: string): T {
+  if (!value) {
+    throw new Error(`${flagName} is required`);
+  }
+
+  try {
+    return JSON.parse(value) as T;
+  } catch (error) {
+    throw new Error(
+      `Invalid JSON for ${flagName}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+export async function resolveTemplatesPath(): Promise<string> {
+  const templatesDir = await TemplatesManagerService.findTemplatesPath();
+  if (!templatesDir) {
+    throw new Error(
+      'Templates folder not found. Create a templates folder or specify templatesPath in toolkit.yaml',
+    );
+  }
+  return templatesDir;
+}
+
+export async function detectMonolithMode(): Promise<boolean> {
+  try {
+    const projectConfig = await ProjectConfigResolver.resolveProjectConfig(process.cwd());
+    return projectConfig.type === 'monolith';
+  } catch {
+    return false;
+  }
+}
+
+export async function loadTextOption(config: {
+  value?: string;
+  filePath?: string;
+  valueFlag: string;
+  fileFlag: string;
+  required?: boolean;
+}): Promise<string | undefined> {
+  const { value, filePath, valueFlag, fileFlag, required = false } = config;
+
+  if (value !== undefined && filePath !== undefined) {
+    throw new Error(`Use only one of ${valueFlag} or ${fileFlag}`);
+  }
+
+  if (filePath !== undefined) {
+    return readFile(filePath, 'utf-8');
+  }
+
+  if (value !== undefined) {
+    return value;
+  }
+
+  if (required) {
+    throw new Error(`${valueFlag} or ${fileFlag} is required`);
+  }
+
+  return undefined;
+}
+
+export function collectOption(value: string, previous: string[] = []): string[] {
+  return [...previous, value];
+}
+
+export function firstTextContent(result: CallToolResult): string {
+  const firstContent = result.content[0];
+  return firstContent?.type === 'text' ? firstContent.text : '';
+}
+
+export function assertToolSuccess(result: CallToolResult): string {
+  const text = firstTextContent(result);
+  if (result.isError) {
+    throw new Error(text || 'Tool execution failed');
+  }
+  return text;
+}

--- a/packages/scaffold-mcp/src/tools/UseScaffoldMethodTool.ts
+++ b/packages/scaffold-mcp/src/tools/UseScaffoldMethodTool.ts
@@ -1,15 +1,12 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { generateStableId } from '@agiflowai/aicode-utils';
-import * as fs from 'node:fs/promises';
-import * as os from 'node:os';
-import * as path from 'node:path';
 import { FileSystemService } from '../services/FileSystemService';
 import { ScaffoldingMethodsService } from '../services/ScaffoldingMethodsService';
+import { writePendingScaffoldLog } from '../utils/scaffoldPendingLog';
 import type { ToolDefinition } from './types';
 
 export class UseScaffoldMethodTool {
   static readonly TOOL_NAME = 'use-scaffold-method';
-  private static readonly TEMP_LOG_DIR = os.tmpdir();
 
   private fileSystemService: FileSystemService;
   private scaffoldingMethodsService: ScaffoldingMethodsService;
@@ -22,37 +19,6 @@ export class UseScaffoldMethodTool {
       templatesPath,
     );
     this.isMonolith = isMonolith;
-  }
-
-  /**
-   * Write scaffold execution info to temp log file for hook processing
-   */
-  private async writePendingScaffoldLog(
-    scaffoldId: string,
-    projectPath: string,
-    featureName: string,
-    generatedFiles: string[],
-  ): Promise<void> {
-    try {
-      const logEntry = {
-        timestamp: Date.now(),
-        scaffoldId,
-        projectPath,
-        featureName,
-        generatedFiles,
-        operation: 'scaffold',
-      };
-
-      const tempLogFile = path.join(
-        UseScaffoldMethodTool.TEMP_LOG_DIR,
-        `scaffold-mcp-pending-${scaffoldId}.jsonl`,
-      );
-
-      await fs.appendFile(tempLogFile, `${JSON.stringify(logEntry)}\n`, 'utf-8');
-    } catch (error) {
-      // Fail silently - logging should not break the tool
-      console.error('Failed to write pending scaffold log:', error);
-    }
   }
 
   /**
@@ -145,12 +111,12 @@ IMPORTANT:
 
       // Write scaffold execution to temp log for hook processing
       if (result.createdFiles && result.createdFiles.length > 0) {
-        await this.writePendingScaffoldLog(
+        await writePendingScaffoldLog({
           scaffoldId,
-          resolvedProjectPath,
-          scaffold_feature_name,
-          result.createdFiles,
-        );
+          projectPath: resolvedProjectPath,
+          featureName: scaffold_feature_name,
+          generatedFiles: result.createdFiles,
+        });
       }
 
       // Append instructions for LLM to review and implement the scaffolded files

--- a/packages/scaffold-mcp/src/utils/scaffoldPendingLog.ts
+++ b/packages/scaffold-mcp/src/utils/scaffoldPendingLog.ts
@@ -1,0 +1,28 @@
+import { appendFile } from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+export async function writePendingScaffoldLog(config: {
+  scaffoldId: string;
+  projectPath: string;
+  featureName: string;
+  generatedFiles: string[];
+}): Promise<void> {
+  const { scaffoldId, projectPath, featureName, generatedFiles } = config;
+
+  try {
+    const logEntry = {
+      timestamp: Date.now(),
+      scaffoldId,
+      projectPath,
+      featureName,
+      generatedFiles,
+      operation: 'scaffold',
+    };
+
+    const tempLogFile = path.join(os.tmpdir(), `scaffold-mcp-pending-${scaffoldId}.jsonl`);
+    await appendFile(tempLogFile, `${JSON.stringify(logEntry)}\n`, 'utf-8');
+  } catch (error) {
+    console.error('Failed to write pending scaffold log:', error);
+  }
+}

--- a/packages/scaffold-mcp/tests/commands/cliParity.test.ts
+++ b/packages/scaffold-mcp/tests/commands/cliParity.test.ts
@@ -1,0 +1,386 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findTemplatesPath: vi.fn(),
+  resolveProjectConfig: vi.fn(),
+  readFile: vi.fn(),
+  generateStableId: vi.fn(),
+  boilerplateList: vi.fn(),
+  getBoilerplate: vi.fn(),
+  useBoilerplate: vi.fn(),
+  listScaffoldingMethods: vi.fn(),
+  listScaffoldingMethodsByTemplate: vi.fn(),
+  useScaffoldMethod: vi.fn(),
+  writePendingScaffoldLog: vi.fn(),
+  generateBoilerplateExecute: vi.fn(),
+  generateFeatureExecute: vi.fn(),
+  generateFileExecute: vi.fn(),
+  writeFileExecute: vi.fn(),
+}));
+
+vi.mock('@agiflowai/aicode-utils', () => ({
+  TemplatesManagerService: {
+    findTemplatesPath: mocks.findTemplatesPath,
+  },
+  ProjectConfigResolver: {
+    hasConfiguration: vi.fn().mockResolvedValue(true),
+    resolveProjectConfig: mocks.resolveProjectConfig,
+  },
+  readFile: mocks.readFile,
+  generateStableId: mocks.generateStableId,
+  icons: {
+    info: 'info',
+    package: 'package',
+    wrench: 'wrench',
+    chart: 'chart',
+    folder: 'folder',
+    config: 'config',
+  },
+  print: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    header: vi.fn(),
+    highlight: vi.fn(),
+    newline: vi.fn(),
+  },
+  messages: {
+    error: vi.fn(),
+    hint: vi.fn(),
+    warning: vi.fn(),
+    success: vi.fn(),
+    loading: vi.fn(),
+  },
+  sections: {
+    createdFiles: vi.fn(),
+    nextSteps: vi.fn(),
+    list: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/services/BoilerplateService', () => ({
+  BoilerplateService: vi.fn(function BoilerplateService() {
+    return {
+      listBoilerplates: mocks.boilerplateList,
+      getBoilerplate: mocks.getBoilerplate,
+      useBoilerplate: mocks.useBoilerplate,
+    };
+  }),
+}));
+
+vi.mock('../../src/services/FileSystemService', () => ({
+  FileSystemService: vi.fn(function FileSystemService() {
+    return {};
+  }),
+}));
+
+vi.mock('../../src/services/ScaffoldingMethodsService', () => ({
+  ScaffoldingMethodsService: vi.fn(function ScaffoldingMethodsService() {
+    return {
+      listScaffoldingMethods: mocks.listScaffoldingMethods,
+      listScaffoldingMethodsByTemplate: mocks.listScaffoldingMethodsByTemplate,
+      useScaffoldMethod: mocks.useScaffoldMethod,
+    };
+  }),
+}));
+
+vi.mock('../../src/utils/scaffoldPendingLog', () => ({
+  writePendingScaffoldLog: mocks.writePendingScaffoldLog,
+}));
+
+vi.mock('../../src/tools', () => ({
+  GenerateBoilerplateTool: vi.fn(function GenerateBoilerplateTool() {
+    return {
+      execute: mocks.generateBoilerplateExecute,
+    };
+  }),
+  GenerateFeatureScaffoldTool: vi.fn(function GenerateFeatureScaffoldTool() {
+    return {
+      execute: mocks.generateFeatureExecute,
+    };
+  }),
+  GenerateBoilerplateFileTool: vi.fn(function GenerateBoilerplateFileTool() {
+    return {
+      execute: mocks.generateFileExecute,
+    };
+  }),
+  WriteToFileTool: vi.fn(function WriteToFileTool() {
+    return {
+      execute: mocks.writeFileExecute,
+    };
+  }),
+}));
+
+async function expectProcessExit(promise: Promise<unknown>) {
+  await expect(promise).rejects.toThrow('process.exit called');
+}
+
+describe('scaffold-mcp CLI parity commands', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findTemplatesPath.mockResolvedValue('/workspace/templates');
+    mocks.resolveProjectConfig.mockResolvedValue({
+      type: 'monorepo',
+      sourceTemplate: 'typescript-lib',
+    });
+    mocks.readFile.mockResolvedValue('file text');
+    mocks.generateStableId.mockReturnValue('abc123');
+    mocks.generateBoilerplateExecute.mockResolvedValue({
+      content: [{ type: 'text', text: '{"success":true}' }],
+    });
+    mocks.generateFeatureExecute.mockResolvedValue({
+      content: [{ type: 'text', text: '{"success":true}' }],
+    });
+    mocks.generateFileExecute.mockResolvedValue({
+      content: [{ type: 'text', text: '{"success":true}' }],
+    });
+    mocks.writeFileExecute.mockResolvedValue({
+      content: [{ type: 'text', text: 'Successfully wrote content to file: /workspace/out.txt' }],
+    });
+  });
+
+  it('passes marker through boilerplate create', async () => {
+    const { boilerplateCommand } = await import('../../src/commands/boilerplate');
+    mocks.getBoilerplate.mockResolvedValue({
+      name: 'scaffold-app',
+      target_folder: 'apps',
+      variables_schema: { required: [] },
+    });
+    mocks.useBoilerplate.mockResolvedValue({
+      success: true,
+      message: 'created',
+      createdFiles: [],
+    });
+
+    await boilerplateCommand.parseAsync([
+      'node',
+      'cli',
+      'create',
+      'scaffold-app',
+      '--vars',
+      '{"appName":"demo"}',
+      '--marker',
+      '@custom-marker',
+    ]);
+
+    expect(mocks.useBoilerplate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        boilerplateName: 'scaffold-app',
+        marker: '@custom-marker',
+      }),
+    );
+  });
+
+  it('maps boilerplate generate options to generate-boilerplate tool arguments', async () => {
+    const { boilerplateCommand } = await import('../../src/commands/boilerplate');
+
+    await boilerplateCommand.parseAsync([
+      'node',
+      'cli',
+      'generate',
+      'scaffold-app',
+      '--template',
+      'vite-react',
+      '--description',
+      'Vite app',
+      '--target-folder',
+      'apps',
+      '--variables',
+      '[{"name":"appName","description":"App name","type":"string","required":true}]',
+      '--include',
+      'package.json',
+      '--include',
+      'src/main.tsx',
+    ]);
+
+    expect(mocks.generateBoilerplateExecute).toHaveBeenCalledWith({
+      templateName: 'vite-react',
+      boilerplateName: 'scaffold-app',
+      description: 'Vite app',
+      instruction: undefined,
+      targetFolder: 'apps',
+      variables: [
+        {
+          name: 'appName',
+          description: 'App name',
+          type: 'string',
+          required: true,
+        },
+      ],
+      includes: ['package.json', 'src/main.tsx'],
+    });
+  });
+
+  it('uses current directory for scaffold list when no project path or template is provided', async () => {
+    const { scaffoldCommand } = await import('../../src/commands/scaffold');
+    mocks.listScaffoldingMethods.mockResolvedValue({
+      methods: [
+        {
+          name: 'scaffold-service',
+          description: 'Service',
+          variables_schema: { required: [] },
+        },
+      ],
+    });
+
+    await scaffoldCommand.parseAsync(['node', 'cli', 'list']);
+
+    expect(mocks.listScaffoldingMethods).toHaveBeenCalledWith(process.cwd(), undefined);
+  });
+
+  it('passes marker through scaffold add and writes pending scaffold log', async () => {
+    const { scaffoldCommand } = await import('../../src/commands/scaffold');
+    mocks.listScaffoldingMethods.mockResolvedValue({
+      methods: [
+        {
+          name: 'scaffold-service',
+          description: 'Service',
+          variables_schema: { required: [] },
+        },
+      ],
+    });
+    mocks.useScaffoldMethod.mockResolvedValue({
+      success: true,
+      message: 'created',
+      createdFiles: ['/workspace/apps/demo/src/service.ts'],
+    });
+
+    await scaffoldCommand.parseAsync([
+      'node',
+      'cli',
+      'add',
+      'scaffold-service',
+      '--project',
+      '/workspace/apps/demo',
+      '--vars',
+      '{"serviceName":"DemoService"}',
+      '--marker',
+      '@custom-marker',
+    ]);
+
+    expect(mocks.useScaffoldMethod).toHaveBeenCalledWith({
+      projectPath: '/workspace/apps/demo',
+      scaffold_feature_name: 'scaffold-service',
+      variables: { serviceName: 'DemoService' },
+      marker: '@custom-marker',
+    });
+    expect(mocks.writePendingScaffoldLog).toHaveBeenCalledWith({
+      scaffoldId: 'abc123',
+      projectPath: '/workspace/apps/demo',
+      featureName: 'scaffold-service',
+      generatedFiles: ['/workspace/apps/demo/src/service.ts'],
+    });
+  });
+
+  it('maps scaffold generate options to generate-feature-scaffold tool arguments', async () => {
+    const { scaffoldCommand } = await import('../../src/commands/scaffold');
+
+    await scaffoldCommand.parseAsync([
+      'node',
+      'cli',
+      'generate',
+      'scaffold-service',
+      '--template',
+      'typescript-lib',
+      '--description',
+      'Generate a service',
+      '--variables',
+      '[{"name":"serviceName","description":"Service name","type":"string","required":true}]',
+      '--include',
+      'src/services/ExampleService.ts',
+      '--pattern',
+      'src/services/**/*.ts',
+    ]);
+
+    expect(mocks.generateFeatureExecute).toHaveBeenCalledWith({
+      templateName: 'typescript-lib',
+      featureName: 'scaffold-service',
+      description: 'Generate a service',
+      instruction: undefined,
+      variables: [
+        {
+          name: 'serviceName',
+          description: 'Service name',
+          type: 'string',
+          required: true,
+        },
+      ],
+      includes: ['src/services/ExampleService.ts'],
+      patterns: ['src/services/**/*.ts'],
+    });
+  });
+
+  it('maps template file create content file input to generate-boilerplate-file tool', async () => {
+    const { templateCommand } = await import('../../src/commands/template');
+
+    await templateCommand.parseAsync([
+      'node',
+      'cli',
+      'file',
+      'create',
+      'src/index.ts',
+      '--template',
+      'typescript-lib',
+      '--content-file',
+      '/tmp/source-template.txt',
+      '--header',
+      'Header text',
+    ]);
+
+    expect(mocks.readFile).toHaveBeenCalledWith('/tmp/source-template.txt', 'utf-8');
+    expect(mocks.generateFileExecute).toHaveBeenCalledWith({
+      templateName: 'typescript-lib',
+      filePath: 'src/index.ts',
+      content: 'file text',
+      sourceFile: undefined,
+      header: 'Header text',
+    });
+  });
+
+  it('rejects template file create when multiple content inputs are provided', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
+    });
+    const { templateCommand } = await import('../../src/commands/template');
+
+    await expectProcessExit(
+      templateCommand.parseAsync([
+        'node',
+        'cli',
+        'file',
+        'create',
+        'src/index.ts',
+        '--template',
+        'typescript-lib',
+        '--content',
+        'inline',
+        '--source-file',
+        '/tmp/source.ts',
+      ]),
+    );
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(mocks.generateFileExecute).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+
+  it('maps file write content file input to write-to-file tool', async () => {
+    const { fileCommand } = await import('../../src/commands/file');
+
+    await fileCommand.parseAsync([
+      'node',
+      'cli',
+      'write',
+      'out.txt',
+      '--content-file',
+      '/tmp/out-content.txt',
+    ]);
+
+    expect(mocks.writeFileExecute).toHaveBeenCalledWith({
+      file_path: 'out.txt',
+      content: 'file text',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add grouped CLI commands for scaffold-mcp admin and utility MCP tool parity
- add marker and scaffold pending-log parity to existing create/add flows
- update CLI docs and add command regression coverage

## Verification
- pnpm build
- pnpm test
- pnpm lint
- pnpm typecheck