### PR TITLE
feat(scaffold-mcp): configurable scaffold-hook write exclusions

### DIFF
--- a/.toolkit/settings.yaml
+++ b/.toolkit/settings.yaml
@@ -18,6 +18,15 @@ scaffold-mcp:
     promptAsSkill: true
 
   hook:
+    # New-file writes matching these globs bypass scaffold enforcement: they are
+    # written directly instead of being denied with scaffold-method guidance.
+    # Applies to all agents. Matched against absolute paths, so prefix with `**`.
+    # Template-specific relaxations belong in that template's scaffold.yaml `exclude`.
+    excludeGlobs:
+      - '**/*.md'
+      - '**/*.mdx'
+      - '**/src/content/**'
+
     claude-code:
       preToolUse:
         # hook reads llm-tool/tool-config from this file at runtime

--- a/packages/aicode-utils/src/types/index.ts
+++ b/packages/aicode-utils/src/types/index.ts
@@ -97,6 +97,14 @@ export interface HookAgentConfig {
  * Hook configuration keyed by agent name.
  */
 export interface HookConfig {
+  /**
+   * Glob patterns whose new-file writes bypass scaffold enforcement (allowed
+   * through directly instead of being denied with scaffold-method guidance).
+   * Matched against absolute paths, so use `**` prefixes (e.g. `**​/*.md`).
+   * Applies to every agent; relaxation that is specific to a template belongs
+   * in that template's `scaffold.yaml` `exclude` list instead.
+   */
+  excludeGlobs?: string[];
   /** Hook config for Claude Code agent. */
   'claude-code'?: HookAgentConfig;
   /** Hook config for Gemini CLI agent. */

--- a/packages/scaffold-mcp/README.md
+++ b/packages/scaffold-mcp/README.md
@@ -303,6 +303,18 @@ Hooks let scaffold-mcp proactively suggest templates when your AI agent creates 
 
 When Claude tries to write a new file, the hook shows available scaffolding methods that match, so Claude can use templates instead of writing from scratch.
 
+**Relaxing enforcement:** to let some files (docs, content, generated code) be written directly, add exclude globs — workspace-wide via `scaffold-mcp.hook.excludeGlobs` in `.toolkit/settings.yaml`, or per-template via a top-level `exclude` in `scaffold.yaml`:
+
+```yaml
+# .toolkit/settings.yaml
+scaffold-mcp:
+  hook:
+    excludeGlobs:
+      - '**/*.md'
+      - '**/*.mdx'
+      - '**/src/content/**'
+```
+
 See [Hooks Documentation](./docs/hooks.md) for details.
 
 ---

--- a/packages/scaffold-mcp/docs/hooks.md
+++ b/packages/scaffold-mcp/docs/hooks.md
@@ -138,6 +138,44 @@ Add to `~/.gemini/settings.json`:
 
 ---
 
+## Relaxing Enforcement
+
+Once a template defines scaffolding methods, the PreToolUse hook denies **new-file writes** that don't go through a scaffolding method. Some files are never scaffolded (Markdown docs, content collections, generated files), and denying them tends to push agents to bypass the hook entirely (e.g. Bash heredocs), which also skips downstream review hooks. Two configurable allow-lists relax this — a write is let through when its path matches **either** one.
+
+### Workspace-wide (`.toolkit/settings.yaml`)
+
+Applies to every agent and every project in the workspace:
+
+```yaml
+scaffold-mcp:
+  hook:
+    excludeGlobs:
+      - '**/*.md'
+      - '**/*.mdx'
+      - '**/src/content/**'
+```
+
+### Per-template (`scaffold.yaml`)
+
+Applies only to projects scaffolded from that template:
+
+```yaml
+# templates/<name>/scaffold.yaml
+exclude:
+  - '**/*.stories.tsx'
+  - '**/__generated__/**'
+```
+
+See [Template Conventions](./template-conventions.md#excluding-files-from-scaffold-enforcement).
+
+### Behavior
+
+- A new-file `Write` is **allowed through directly** when its absolute path matches a glob in **either** list (use `**` prefixes; dotfile traversal is enabled).
+- The two lists are additive — neither requires the other.
+- With no `excludeGlobs` / `exclude` configured, the broad enforcement stays in effect.
+
+---
+
 ## Session Tracking
 
 Hooks track executions per session:

--- a/packages/scaffold-mcp/docs/template-conventions.md
+++ b/packages/scaffold-mcp/docs/template-conventions.md
@@ -8,6 +8,7 @@ Comprehensive guide for creating templates and understanding the scaffolding sys
 - [Template Structure](#template-structure)
 - [Configuration Files](#configuration-files)
   - [scaffold.yaml](#scaffoldyaml)
+    - [Excluding Files from Scaffold Enforcement](#excluding-files-from-scaffold-enforcement)
   - [Variables Schema](#variables-schema)
   - [Include Patterns](#include-patterns)
 - [Liquid Template Syntax](#liquid-template-syntax)
@@ -253,6 +254,32 @@ boilerplate:
     includes:
       # ...
 ```
+
+#### Excluding Files from Scaffold Enforcement
+
+When the [scaffold hooks](./hooks.md) are enabled, agents are blocked from writing **new** files directly once a template defines any scaffolding methods — they are nudged to use a scaffolding method instead. Some files are never scaffolded (docs, content collections, generated files), so the optional top-level `exclude` key lists glob patterns whose new-file writes are allowed through directly:
+
+```yaml
+# scaffold.yaml
+exclude:
+  - '**/*.md'
+  - '**/*.mdx'
+  - '**/src/content/**'
+
+boilerplate:
+  - name: nextjs-15-app
+    # ...
+
+features:
+  - name: scaffold-nextjs-page
+    # ...
+```
+
+- **Scope:** applies to every project scaffolded from this template.
+- **Matching:** globs are matched against the **absolute** file path (prefix with `**`), with dotfile traversal enabled.
+- **Precedence:** a new-file write is allowed through when it matches *either* this template-level `exclude` **or** the workspace-wide `scaffold-mcp.hook.excludeGlobs` in `.toolkit/settings.yaml`. Otherwise, if the template defines any scaffolding methods, the write is denied with guidance.
+
+Use a template's `exclude` for relaxations specific to that template's structure (e.g. `**/__generated__/**`, `**/*.stories.tsx`); use the workspace-wide setting for patterns that should be relaxed everywhere. See [Hooks Integration](./hooks.md#relaxing-enforcement) for the global setting.
 
 ### Variables Schema
 

--- a/packages/scaffold-mcp/package.json
+++ b/packages/scaffold-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agiflowai/scaffold-mcp",
   "description": "MCP server for scaffolding applications with boilerplate templates",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "AGPL-3.0",
   "author": "AgiflowIO",
   "repository": {

--- a/packages/scaffold-mcp/src/commands/hook.ts
+++ b/packages/scaffold-mcp/src/commands/hook.ts
@@ -164,8 +164,11 @@ export const hookCommand = new Command('hook')
       // Read per-agent per-method config; CLI flags take precedence
       const toolkitConfig = await TemplatesManagerService.readToolkitConfig();
       const hookConfig = toolkitConfig?.['scaffold-mcp']?.hook;
+      // Exclude non-agent keys (e.g. excludeGlobs) so the value narrows to HookAgentConfig.
       const methodConfig =
-        hookConfig?.[agent as keyof HookConfig]?.[hookMethod as keyof HookAgentConfig];
+        hookConfig?.[agent as Exclude<keyof HookConfig, 'excludeGlobs'>]?.[
+          hookMethod as keyof HookAgentConfig
+        ];
 
       const marker = options.marker ?? '@scaffold-generated';
       const configuredFallback = resolveFallbackConfig(methodConfig as never);

--- a/packages/scaffold-mcp/src/hooks/claudeCode/useScaffoldMethod.ts
+++ b/packages/scaffold-mcp/src/hooks/claudeCode/useScaffoldMethod.ts
@@ -25,18 +25,13 @@ import type {
   LogEntry,
   PendingScaffoldLogEntry,
 } from '@agiflowai/hooks-adapter';
-import {
-  ExecutionLogService,
-  DECISION_SKIP,
-  DECISION_DENY,
-  DECISION_ALLOW,
-} from '@agiflowai/hooks-adapter';
+import { ExecutionLogService, DECISION_SKIP, DECISION_DENY, DECISION_ALLOW } from '@agiflowai/hooks-adapter';
 import { ListScaffoldingMethodsTool } from '../../tools';
 import { TemplatesManagerService, ProjectFinderService } from '@agiflowai/aicode-utils';
 import path from 'node:path';
 import fs from 'node:fs/promises';
 import os from 'node:os';
-import { formatScaffoldMethodsHookMessage, resolveNewFileWriteTarget } from '../shared';
+import { formatScaffoldMethodsHookMessage, resolveNewFileWriteTarget, isNonScaffoldableTarget } from '../shared';
 
 /**
  * Scaffold method definition from list-scaffolding-methods tool
@@ -109,15 +104,21 @@ export class UseScaffoldMethodHook {
       }
 
       const filePath = context.tool_input?.file_path;
-      const absoluteFilePath = await resolveNewFileWriteTarget(
-        context.cwd,
-        context.tool_name,
-        filePath,
-      );
+      const absoluteFilePath = await resolveNewFileWriteTarget(context.cwd, context.tool_name, filePath);
       if (!absoluteFilePath || !filePath) {
         return {
           decision: DECISION_SKIP,
           message: 'Not a new file write operation',
+        };
+      }
+
+      // Content files (markdown/MDX, src/content/**) are never scaffoldable. Allow the
+      // write directly so agents don't bypass this hook (and downstream review hooks)
+      // by falling back to Bash heredocs.
+      if (isNonScaffoldableTarget(absoluteFilePath)) {
+        return {
+          decision: DECISION_ALLOW,
+          message: 'Content file (non-scaffoldable) - writing directly.',
         };
       }
 
@@ -250,9 +251,7 @@ export class UseScaffoldMethodHook {
       const filePath = context.tool_input?.file_path;
 
       const actualToolName =
-        context.tool_name === 'mcp__one-mcp__use_tool'
-          ? context.tool_input?.toolName
-          : context.tool_name;
+        context.tool_name === 'mcp__one-mcp__use_tool' ? context.tool_input?.toolName : context.tool_name;
 
       // Check if this is a use-scaffold-method tool execution
       if (actualToolName === 'use-scaffold-method') {
@@ -272,9 +271,7 @@ export class UseScaffoldMethodHook {
       // Only process file edit/write operations
       if (
         !filePath ||
-        (context.tool_name !== 'Edit' &&
-          context.tool_name !== 'Write' &&
-          context.tool_name !== 'Update')
+        (context.tool_name !== 'Edit' && context.tool_name !== 'Write' && context.tool_name !== 'Update')
       ) {
         return {
           decision: DECISION_SKIP,
@@ -456,10 +453,7 @@ async function getEditedScaffoldFiles(
     const editedFiles: string[] = [];
 
     for (const entry of entries) {
-      if (
-        entry.operation === 'scaffold-file-edit' &&
-        entry.filePath.startsWith(`scaffold-edit-${scaffoldId}-`)
-      ) {
+      if (entry.operation === 'scaffold-file-edit' && entry.filePath.startsWith(`scaffold-edit-${scaffoldId}-`)) {
         // Extract the file path from the edit key
         const filePath = entry.filePath.replace(`scaffold-edit-${scaffoldId}-`, '');
         editedFiles.push(filePath);
@@ -519,9 +513,7 @@ async function processPendingScaffoldLogs(sessionId: string, scaffoldId: string)
         await fs.unlink(tempLogFile);
       } catch (unlinkError: unknown) {
         // ENOENT means file was already deleted — safe to ignore; log unexpected errors
-        if (
-          !(unlinkError instanceof Error && 'code' in unlinkError && unlinkError.code === 'ENOENT')
-        ) {
+        if (!(unlinkError instanceof Error && 'code' in unlinkError && unlinkError.code === 'ENOENT')) {
           console.error('processPendingScaffoldLogs: failed to delete temp log file:', unlinkError);
         }
       }

--- a/packages/scaffold-mcp/src/hooks/claudeCode/useScaffoldMethod.ts
+++ b/packages/scaffold-mcp/src/hooks/claudeCode/useScaffoldMethod.ts
@@ -25,13 +25,23 @@ import type {
   LogEntry,
   PendingScaffoldLogEntry,
 } from '@agiflowai/hooks-adapter';
-import { ExecutionLogService, DECISION_SKIP, DECISION_DENY, DECISION_ALLOW } from '@agiflowai/hooks-adapter';
+import {
+  ExecutionLogService,
+  DECISION_SKIP,
+  DECISION_DENY,
+  DECISION_ALLOW,
+} from '@agiflowai/hooks-adapter';
 import { ListScaffoldingMethodsTool } from '../../tools';
 import { TemplatesManagerService, ProjectFinderService } from '@agiflowai/aicode-utils';
 import path from 'node:path';
 import fs from 'node:fs/promises';
 import os from 'node:os';
-import { formatScaffoldMethodsHookMessage, resolveNewFileWriteTarget, isNonScaffoldableTarget } from '../shared';
+import {
+  formatScaffoldMethodsHookMessage,
+  resolveNewFileWriteTarget,
+  matchesExcludeGlob,
+  getGlobalExcludeGlobs,
+} from '../shared';
 
 /**
  * Scaffold method definition from list-scaffolding-methods tool
@@ -46,6 +56,8 @@ interface ScaffoldMethod {
  */
 interface ScaffoldMethodsResponse {
   methods?: ScaffoldMethod[];
+  /** Template-level exclude globs from scaffold.yaml (see {@link matchesExcludeGlob}). */
+  excludeGlobs?: string[];
   nextCursor?: string;
 }
 
@@ -62,6 +74,7 @@ interface ExecutionLogServiceWithLoadLog extends ExecutionLogService {
 function isScaffoldMethodsResponse(value: unknown): value is ScaffoldMethodsResponse {
   if (typeof value !== 'object' || value === null) return false;
   if ('methods' in value && !Array.isArray(value.methods)) return false;
+  if ('excludeGlobs' in value && !Array.isArray(value.excludeGlobs)) return false;
   if ('nextCursor' in value && typeof value.nextCursor !== 'string') return false;
   return true;
 }
@@ -104,7 +117,11 @@ export class UseScaffoldMethodHook {
       }
 
       const filePath = context.tool_input?.file_path;
-      const absoluteFilePath = await resolveNewFileWriteTarget(context.cwd, context.tool_name, filePath);
+      const absoluteFilePath = await resolveNewFileWriteTarget(
+        context.cwd,
+        context.tool_name,
+        filePath,
+      );
       if (!absoluteFilePath || !filePath) {
         return {
           decision: DECISION_SKIP,
@@ -112,13 +129,14 @@ export class UseScaffoldMethodHook {
         };
       }
 
-      // Content files (markdown/MDX, src/content/**) are never scaffoldable. Allow the
-      // write directly so agents don't bypass this hook (and downstream review hooks)
-      // by falling back to Bash heredocs.
-      if (isNonScaffoldableTarget(absoluteFilePath)) {
+      // Writes matching the workspace-wide excludeGlobs (scaffold-mcp.hook.excludeGlobs
+      // in .toolkit/settings.yaml) bypass scaffold enforcement so agents don't route
+      // around this hook (and the downstream review hooks) via Bash heredocs.
+      const globalExcludeGlobs = await getGlobalExcludeGlobs(context.cwd);
+      if (matchesExcludeGlob(absoluteFilePath, globalExcludeGlobs)) {
         return {
           decision: DECISION_ALLOW,
-          message: 'Content file (non-scaffoldable) - writing directly.',
+          message: 'File matches configured excludeGlobs - writing directly.',
         };
       }
 
@@ -192,6 +210,15 @@ export class UseScaffoldMethodHook {
       }
       const data = parsed;
 
+      // Per-template relaxation: writes matching the template's scaffold.yaml `exclude`
+      // globs bypass enforcement even when scaffold methods exist.
+      if (matchesExcludeGlob(absoluteFilePath, data.excludeGlobs)) {
+        return {
+          decision: DECISION_ALLOW,
+          message: 'File matches template exclude globs - writing directly.',
+        };
+      }
+
       if (!data.methods || data.methods.length === 0) {
         // No methods available - allow with guidance
         await executionLog.logExecution({
@@ -251,7 +278,9 @@ export class UseScaffoldMethodHook {
       const filePath = context.tool_input?.file_path;
 
       const actualToolName =
-        context.tool_name === 'mcp__one-mcp__use_tool' ? context.tool_input?.toolName : context.tool_name;
+        context.tool_name === 'mcp__one-mcp__use_tool'
+          ? context.tool_input?.toolName
+          : context.tool_name;
 
       // Check if this is a use-scaffold-method tool execution
       if (actualToolName === 'use-scaffold-method') {
@@ -271,7 +300,9 @@ export class UseScaffoldMethodHook {
       // Only process file edit/write operations
       if (
         !filePath ||
-        (context.tool_name !== 'Edit' && context.tool_name !== 'Write' && context.tool_name !== 'Update')
+        (context.tool_name !== 'Edit' &&
+          context.tool_name !== 'Write' &&
+          context.tool_name !== 'Update')
       ) {
         return {
           decision: DECISION_SKIP,
@@ -453,7 +484,10 @@ async function getEditedScaffoldFiles(
     const editedFiles: string[] = [];
 
     for (const entry of entries) {
-      if (entry.operation === 'scaffold-file-edit' && entry.filePath.startsWith(`scaffold-edit-${scaffoldId}-`)) {
+      if (
+        entry.operation === 'scaffold-file-edit' &&
+        entry.filePath.startsWith(`scaffold-edit-${scaffoldId}-`)
+      ) {
         // Extract the file path from the edit key
         const filePath = entry.filePath.replace(`scaffold-edit-${scaffoldId}-`, '');
         editedFiles.push(filePath);
@@ -513,7 +547,9 @@ async function processPendingScaffoldLogs(sessionId: string, scaffoldId: string)
         await fs.unlink(tempLogFile);
       } catch (unlinkError: unknown) {
         // ENOENT means file was already deleted — safe to ignore; log unexpected errors
-        if (!(unlinkError instanceof Error && 'code' in unlinkError && unlinkError.code === 'ENOENT')) {
+        if (
+          !(unlinkError instanceof Error && 'code' in unlinkError && unlinkError.code === 'ENOENT')
+        ) {
           console.error('processPendingScaffoldLogs: failed to delete temp log file:', unlinkError);
         }
       }

--- a/packages/scaffold-mcp/src/hooks/geminiCli/useScaffoldMethod.ts
+++ b/packages/scaffold-mcp/src/hooks/geminiCli/useScaffoldMethod.ts
@@ -17,11 +17,26 @@
  * - Mutating context object
  */
 
-import type { GeminiCliHookInput, HookResponse, ScaffoldExecution, LogEntry } from '@agiflowai/hooks-adapter';
-import { ExecutionLogService, DECISION_SKIP, DECISION_DENY, DECISION_ALLOW } from '@agiflowai/hooks-adapter';
+import type {
+  GeminiCliHookInput,
+  HookResponse,
+  ScaffoldExecution,
+  LogEntry,
+} from '@agiflowai/hooks-adapter';
+import {
+  ExecutionLogService,
+  DECISION_SKIP,
+  DECISION_DENY,
+  DECISION_ALLOW,
+} from '@agiflowai/hooks-adapter';
 import { ListScaffoldingMethodsTool } from '../../tools/ListScaffoldingMethodsTool';
 import { TemplatesManagerService, ProjectFinderService } from '@agiflowai/aicode-utils';
-import { formatScaffoldMethodsHookMessage, resolveNewFileWriteTarget, isNonScaffoldableTarget } from '../shared';
+import {
+  formatScaffoldMethodsHookMessage,
+  resolveNewFileWriteTarget,
+  matchesExcludeGlob,
+  getGlobalExcludeGlobs,
+} from '../shared';
 
 /**
  * Scaffold method definition from list-scaffolding-methods tool
@@ -40,6 +55,8 @@ interface ScaffoldMethod {
  */
 interface ScaffoldMethodsResponse {
   methods?: ScaffoldMethod[];
+  /** Template-level exclude globs from scaffold.yaml (see {@link matchesExcludeGlob}). */
+  excludeGlobs?: string[];
   nextCursor?: string;
 }
 
@@ -68,7 +85,11 @@ export class UseScaffoldMethodHook {
   async preToolUse(context: GeminiCliHookInput): Promise<HookResponse> {
     try {
       const filePath = context.tool_input?.file_path;
-      const absoluteFilePath = await resolveNewFileWriteTarget(context.cwd, context.tool_name, filePath);
+      const absoluteFilePath = await resolveNewFileWriteTarget(
+        context.cwd,
+        context.tool_name,
+        filePath,
+      );
       if (!absoluteFilePath || !filePath) {
         return {
           decision: DECISION_SKIP,
@@ -76,13 +97,14 @@ export class UseScaffoldMethodHook {
         };
       }
 
-      // Content files (markdown/MDX, src/content/**) are never scaffoldable. Allow the
-      // write directly so agents don't bypass this hook (and downstream review hooks)
-      // by falling back to Bash heredocs.
-      if (isNonScaffoldableTarget(absoluteFilePath)) {
+      // Writes matching the workspace-wide excludeGlobs (scaffold-mcp.hook.excludeGlobs
+      // in .toolkit/settings.yaml) bypass scaffold enforcement so agents don't route
+      // around this hook (and the downstream review hooks) via Bash heredocs.
+      const globalExcludeGlobs = await getGlobalExcludeGlobs(context.cwd);
+      if (matchesExcludeGlob(absoluteFilePath, globalExcludeGlobs)) {
         return {
           decision: DECISION_ALLOW,
-          message: 'Content file (non-scaffoldable) - writing directly.',
+          message: 'File matches configured excludeGlobs - writing directly.',
         };
       }
 
@@ -162,6 +184,15 @@ export class UseScaffoldMethodHook {
 
       const data: ScaffoldMethodsResponse = JSON.parse(resultText);
 
+      // Per-template relaxation: writes matching the template's scaffold.yaml `exclude`
+      // globs bypass enforcement even when scaffold methods exist.
+      if (matchesExcludeGlob(absoluteFilePath, data.excludeGlobs)) {
+        return {
+          decision: DECISION_ALLOW,
+          message: 'File matches template exclude globs - writing directly.',
+        };
+      }
+
       if (!data.methods || data.methods.length === 0) {
         // No methods available - still deny to guide AI
         await executionLog.logExecution({
@@ -219,7 +250,9 @@ export class UseScaffoldMethodHook {
 
       // Extract actual tool name (handle both direct calls and MCP proxy calls)
       const actualToolName =
-        context.tool_name === 'mcp__one-mcp__use_tool' ? context.tool_input?.toolName : context.tool_name;
+        context.tool_name === 'mcp__one-mcp__use_tool'
+          ? context.tool_input?.toolName
+          : context.tool_name;
 
       // Check if this is a use-scaffold-method tool execution
       if (actualToolName === 'use-scaffold-method') {
@@ -404,7 +437,10 @@ async function getEditedScaffoldFiles(
     const editedFiles: string[] = [];
 
     for (const entry of entries) {
-      if (entry.operation === 'scaffold-file-edit' && entry.filePath.startsWith(`scaffold-edit-${scaffoldId}-`)) {
+      if (
+        entry.operation === 'scaffold-file-edit' &&
+        entry.filePath.startsWith(`scaffold-edit-${scaffoldId}-`)
+      ) {
         // Extract the file path from the edit key
         const filePath = entry.filePath.replace(`scaffold-edit-${scaffoldId}-`, '');
         editedFiles.push(filePath);

--- a/packages/scaffold-mcp/src/hooks/geminiCli/useScaffoldMethod.ts
+++ b/packages/scaffold-mcp/src/hooks/geminiCli/useScaffoldMethod.ts
@@ -17,21 +17,11 @@
  * - Mutating context object
  */
 
-import type {
-  GeminiCliHookInput,
-  HookResponse,
-  ScaffoldExecution,
-  LogEntry,
-} from '@agiflowai/hooks-adapter';
-import {
-  ExecutionLogService,
-  DECISION_SKIP,
-  DECISION_DENY,
-  DECISION_ALLOW,
-} from '@agiflowai/hooks-adapter';
+import type { GeminiCliHookInput, HookResponse, ScaffoldExecution, LogEntry } from '@agiflowai/hooks-adapter';
+import { ExecutionLogService, DECISION_SKIP, DECISION_DENY, DECISION_ALLOW } from '@agiflowai/hooks-adapter';
 import { ListScaffoldingMethodsTool } from '../../tools/ListScaffoldingMethodsTool';
 import { TemplatesManagerService, ProjectFinderService } from '@agiflowai/aicode-utils';
-import { formatScaffoldMethodsHookMessage, resolveNewFileWriteTarget } from '../shared';
+import { formatScaffoldMethodsHookMessage, resolveNewFileWriteTarget, isNonScaffoldableTarget } from '../shared';
 
 /**
  * Scaffold method definition from list-scaffolding-methods tool
@@ -78,15 +68,21 @@ export class UseScaffoldMethodHook {
   async preToolUse(context: GeminiCliHookInput): Promise<HookResponse> {
     try {
       const filePath = context.tool_input?.file_path;
-      const absoluteFilePath = await resolveNewFileWriteTarget(
-        context.cwd,
-        context.tool_name,
-        filePath,
-      );
+      const absoluteFilePath = await resolveNewFileWriteTarget(context.cwd, context.tool_name, filePath);
       if (!absoluteFilePath || !filePath) {
         return {
           decision: DECISION_SKIP,
           message: 'Not a new file write operation',
+        };
+      }
+
+      // Content files (markdown/MDX, src/content/**) are never scaffoldable. Allow the
+      // write directly so agents don't bypass this hook (and downstream review hooks)
+      // by falling back to Bash heredocs.
+      if (isNonScaffoldableTarget(absoluteFilePath)) {
+        return {
+          decision: DECISION_ALLOW,
+          message: 'Content file (non-scaffoldable) - writing directly.',
         };
       }
 
@@ -223,9 +219,7 @@ export class UseScaffoldMethodHook {
 
       // Extract actual tool name (handle both direct calls and MCP proxy calls)
       const actualToolName =
-        context.tool_name === 'mcp__one-mcp__use_tool'
-          ? context.tool_input?.toolName
-          : context.tool_name;
+        context.tool_name === 'mcp__one-mcp__use_tool' ? context.tool_input?.toolName : context.tool_name;
 
       // Check if this is a use-scaffold-method tool execution
       if (actualToolName === 'use-scaffold-method') {
@@ -410,10 +404,7 @@ async function getEditedScaffoldFiles(
     const editedFiles: string[] = [];
 
     for (const entry of entries) {
-      if (
-        entry.operation === 'scaffold-file-edit' &&
-        entry.filePath.startsWith(`scaffold-edit-${scaffoldId}-`)
-      ) {
+      if (entry.operation === 'scaffold-file-edit' && entry.filePath.startsWith(`scaffold-edit-${scaffoldId}-`)) {
         // Extract the file path from the edit key
         const filePath = entry.filePath.replace(`scaffold-edit-${scaffoldId}-`, '');
         editedFiles.push(filePath);

--- a/packages/scaffold-mcp/src/hooks/shared.ts
+++ b/packages/scaffold-mcp/src/hooks/shared.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import fs from 'node:fs/promises';
 import { minimatch } from 'minimatch';
+import { TemplatesManagerService } from '@agiflowai/aicode-utils';
 
 interface ScaffoldMethodSummary {
   name: string;
@@ -15,24 +16,48 @@ export const MAX_REQUIRED_VARS_IN_HOOK = 3;
 export const REQUIRED_VARS_METHOD_LIMIT = 2;
 
 /**
- * Globs for new-file write targets that are never scaffoldable source files.
+ * Returns true when an absolute write target matches any of the given exclude globs.
+ *
  * Scaffold methods carry no target glob, so the hook cannot tell whether a method
- * applies to a given path. Without this allow-list it denies every new-file write
- * once any method exists, which pushes agents to bypass the hook via Bash heredocs
- * (skipping downstream review hooks). Content files matching these globs are written
- * directly instead.
- */
-export const NON_SCAFFOLDABLE_GLOBS = ['**/src/content/**', '**/*.md', '**/*.mdx'];
-
-/**
- * Returns true when an absolute write target is clearly non-scaffoldable content
- * (markdown/MDX docs, or anything under a src/content directory).
+ * applies to a given path: once any method exists it denies every new-file write,
+ * which pushes agents to bypass the hook via Bash heredocs (skipping downstream
+ * review hooks). Exclude globs are the configured escape hatch — matching writes are
+ * allowed through directly. Globs come from two sources: workspace-wide
+ * (`scaffold-mcp.hook.excludeGlobs` in .toolkit/settings.yaml, see
+ * {@link getGlobalExcludeGlobs}) and per-template (`exclude` in scaffold.yaml).
  *
  * `dot: true` lets the globs traverse dot-directories (e.g. worktree paths) so a
- * content file nested under one is not misclassified as scaffoldable.
+ * file nested under one is not misclassified.
+ *
+ * @param absPath - Absolute path of the new-file write target.
+ * @param globs - Glob patterns to match against; empty/undefined matches nothing.
+ * @returns True when `absPath` matches at least one glob.
  */
-export function isNonScaffoldableTarget(absPath: string): boolean {
-  return NON_SCAFFOLDABLE_GLOBS.some((glob) => minimatch(absPath, glob, { dot: true }));
+export function matchesExcludeGlob(absPath: string, globs?: string[]): boolean {
+  if (!globs || globs.length === 0) {
+    return false;
+  }
+  return globs.some((glob) => minimatch(absPath, glob, { dot: true }));
+}
+
+/**
+ * Loads the workspace-wide scaffold-enforcement exclude globs from the toolkit
+ * config (`scaffold-mcp.hook.excludeGlobs` in .toolkit/settings.yaml).
+ *
+ * Fails open (returns an empty array) when the config is missing or unreadable so a
+ * broken config never blocks writes.
+ *
+ * @param cwd - Directory to resolve the workspace config from (walks up to the root).
+ * @returns The configured exclude globs, or an empty array when none are set.
+ */
+export async function getGlobalExcludeGlobs(cwd: string): Promise<string[]> {
+  try {
+    const config = await TemplatesManagerService.readToolkitConfig(cwd);
+    const globs = config?.['scaffold-mcp']?.hook?.excludeGlobs;
+    return Array.isArray(globs) ? globs : [];
+  } catch {
+    return [];
+  }
 }
 
 export async function resolveNewFileWriteTarget(

--- a/packages/scaffold-mcp/src/hooks/shared.ts
+++ b/packages/scaffold-mcp/src/hooks/shared.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import fs from 'node:fs/promises';
+import { minimatch } from 'minimatch';
 
 interface ScaffoldMethodSummary {
   name: string;
@@ -12,6 +13,27 @@ interface ScaffoldMethodSummary {
 export const MAX_SCAFFOLD_METHODS_IN_HOOK = 5;
 export const MAX_REQUIRED_VARS_IN_HOOK = 3;
 export const REQUIRED_VARS_METHOD_LIMIT = 2;
+
+/**
+ * Globs for new-file write targets that are never scaffoldable source files.
+ * Scaffold methods carry no target glob, so the hook cannot tell whether a method
+ * applies to a given path. Without this allow-list it denies every new-file write
+ * once any method exists, which pushes agents to bypass the hook via Bash heredocs
+ * (skipping downstream review hooks). Content files matching these globs are written
+ * directly instead.
+ */
+export const NON_SCAFFOLDABLE_GLOBS = ['**/src/content/**', '**/*.md', '**/*.mdx'];
+
+/**
+ * Returns true when an absolute write target is clearly non-scaffoldable content
+ * (markdown/MDX docs, or anything under a src/content directory).
+ *
+ * `dot: true` lets the globs traverse dot-directories (e.g. worktree paths) so a
+ * content file nested under one is not misclassified as scaffoldable.
+ */
+export function isNonScaffoldableTarget(absPath: string): boolean {
+  return NON_SCAFFOLDABLE_GLOBS.some((glob) => minimatch(absPath, glob, { dot: true }));
+}
 
 export async function resolveNewFileWriteTarget(
   cwd: string,

--- a/packages/scaffold-mcp/src/services/ScaffoldConfigLoader.ts
+++ b/packages/scaffold-mcp/src/services/ScaffoldConfigLoader.ts
@@ -31,6 +31,10 @@ const ScaffoldConfigEntrySchema = z.object({
 // Zod schema for the entire scaffold.yaml structure
 const ScaffoldYamlSchema = z
   .object({
+    // Glob patterns whose new-file writes bypass scaffold enforcement for projects
+    // using this template (allowed through directly instead of denied). Declared
+    // explicitly so the catchall below does not treat it as a scaffold entry.
+    exclude: z.array(z.string()).optional(),
     boilerplate: z
       .union([ScaffoldConfigEntrySchema, z.array(ScaffoldConfigEntrySchema)])
       .optional(),

--- a/packages/scaffold-mcp/src/services/ScaffoldingMethodsService.ts
+++ b/packages/scaffold-mcp/src/services/ScaffoldingMethodsService.ts
@@ -100,6 +100,10 @@ export class ScaffoldingMethodsService {
     const scaffoldContent = await this.fileSystem.readFile(scaffoldYamlPath, 'utf8');
     const architectConfig = yaml.load(scaffoldContent) as ArchitectConfig;
 
+    // Template-level enforcement relaxation: new-file writes matching these globs
+    // are allowed through directly by the scaffold hook.
+    const excludeGlobs = Array.isArray(architectConfig.exclude) ? architectConfig.exclude : [];
+
     const methods: ScaffoldMethod[] = [];
 
     if (architectConfig.features && Array.isArray(architectConfig.features)) {
@@ -122,14 +126,15 @@ export class ScaffoldingMethodsService {
       });
     }
 
-    return { templatePath, methods };
+    return { templatePath, methods, excludeGlobs };
   }
 
   async listScaffoldingMethodsByTemplate(
     templateName: string,
     cursor?: string,
   ): Promise<ListScaffoldingMethodsResult> {
-    const { templatePath, methods } = await this.collectAllMethodsByTemplate(templateName);
+    const { templatePath, methods, excludeGlobs } =
+      await this.collectAllMethodsByTemplate(templateName);
 
     // Apply pagination with metadata
     const paginatedResult = PaginationHelper.paginate(methods, cursor);
@@ -138,6 +143,7 @@ export class ScaffoldingMethodsService {
       sourceTemplate: templateName,
       templatePath,
       methods: paginatedResult.items,
+      excludeGlobs,
       nextCursor: paginatedResult.nextCursor,
       _meta: paginatedResult._meta,
     };

--- a/packages/scaffold-mcp/src/services/ScaffoldingMethodsService.ts
+++ b/packages/scaffold-mcp/src/services/ScaffoldingMethodsService.ts
@@ -26,6 +26,11 @@ export interface ListScaffoldingMethodsResult {
   sourceTemplate: string;
   templatePath: string;
   methods: ScaffoldMethod[];
+  /**
+   * Template-level glob patterns (from scaffold.yaml `exclude`) whose new-file
+   * writes bypass scaffold enforcement. Template-wide, so repeated on every page.
+   */
+  excludeGlobs?: string[];
   nextCursor?: string; // Cursor token for pagination (next item index)
   _meta?: {
     total: number; // Total number of methods
@@ -78,7 +83,7 @@ export class ScaffoldingMethodsService {
    */
   private async collectAllMethodsByTemplate(
     templateName: string,
-  ): Promise<{ templatePath: string; methods: ScaffoldMethod[] }> {
+  ): Promise<{ templatePath: string; methods: ScaffoldMethod[]; excludeGlobs: string[] }> {
     const templatePath = await this.findTemplatePath(templateName);
 
     if (!templatePath) {

--- a/packages/scaffold-mcp/tests/hooks/claudeCode/useScaffoldMethod.test.ts
+++ b/packages/scaffold-mcp/tests/hooks/claudeCode/useScaffoldMethod.test.ts
@@ -64,7 +64,9 @@ const { mockExecute, mockHasExecuted, mockLogExecution, mockLoadLog } = vi.hoist
 
 vi.mock(
   '@agiflowai/hooks-adapter',
-  async (importOriginal: () => Promise<typeof import('@agiflowai/hooks-adapter')>): Promise<object> => {
+  async (
+    importOriginal: () => Promise<typeof import('@agiflowai/hooks-adapter')>,
+  ): Promise<object> => {
     const actual = await importOriginal<typeof import('@agiflowai/hooks-adapter')>();
     return {
       ...actual,
@@ -85,6 +87,9 @@ vi.mock('@agiflowai/aicode-utils', (): object => ({
   TemplatesManagerService: {
     findTemplatesPath: vi.fn().mockResolvedValue('/test/templates'),
     getWorkspaceRoot: vi.fn().mockResolvedValue('/test'),
+    readToolkitConfig: vi.fn().mockResolvedValue({
+      'scaffold-mcp': { hook: { excludeGlobs: ['**/*.md', '**/*.mdx', '**/src/content/**'] } },
+    }),
   },
   // Vitest v4 requires a regular function (not arrow) for constructor mocks
   // biome-ignore lint/complexity/useArrowFunction: regular function required for `new` call in Vitest v4
@@ -114,7 +119,9 @@ vi.mock('node:fs/promises', (): object => ({
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makePreToolUseContext(overrides: Partial<ClaudeCodePreToolUseInput> = {}): ClaudeCodePreToolUseInput {
+function makePreToolUseContext(
+  overrides: Partial<ClaudeCodePreToolUseInput> = {},
+): ClaudeCodePreToolUseInput {
   return {
     hook_event_name: 'PreToolUse',
     tool_name: 'Write',
@@ -128,10 +135,14 @@ function makePreToolUseContext(overrides: Partial<ClaudeCodePreToolUseInput> = {
   };
 }
 
-function makeMethodsResult(methods: MockMethodEntry[], nextCursor?: string): MockToolResult {
+function makeMethodsResult(
+  methods: MockMethodEntry[],
+  nextCursor?: string,
+  excludeGlobs?: string[],
+): MockToolResult {
   return {
     isError: false,
-    content: [{ type: 'text', text: JSON.stringify({ methods, nextCursor }) }],
+    content: [{ type: 'text', text: JSON.stringify({ methods, nextCursor, excludeGlobs }) }],
   };
 }
 
@@ -179,7 +190,9 @@ describe('UseScaffoldMethodHook.preToolUse', (): void => {
   });
 
   it('should skip files outside the cwd', async (): Promise<void> => {
-    const result = await hook.preToolUse(makePreToolUseContext({ tool_input: { file_path: '/other/path/file.ts' } }));
+    const result = await hook.preToolUse(
+      makePreToolUseContext({ tool_input: { file_path: '/other/path/file.ts' } }),
+    );
     expect(result.decision).toBe(DECISION_SKIP);
   });
 
@@ -219,8 +232,10 @@ describe('UseScaffoldMethodHook.preToolUse', (): void => {
     expect(result.message).toContain('- **scaffold-component**: Generate a new React component');
   });
 
-  it('should allow new-file writes to non-scaffoldable content paths even when methods exist', async (): Promise<void> => {
-    mockExecute.mockResolvedValue(makeMethodsResult([{ name: 'scaffold-route', description: 'Generate a new route' }]));
+  it('should allow new-file writes matching configured global excludeGlobs even when methods exist', async (): Promise<void> => {
+    mockExecute.mockResolvedValue(
+      makeMethodsResult([{ name: 'scaffold-route', description: 'Generate a new route' }]),
+    );
 
     const result = await hook.preToolUse(
       makePreToolUseContext({
@@ -229,13 +244,38 @@ describe('UseScaffoldMethodHook.preToolUse', (): void => {
     );
 
     expect(result.decision).toBe(DECISION_ALLOW);
-    expect(result.message).toContain('non-scaffoldable');
-    // Content files short-circuit before scaffold methods are ever consulted.
+    expect(result.message).toContain('excludeGlobs');
+    // Global excludeGlobs short-circuit before scaffold methods are ever consulted.
     expect(mockExecute).not.toHaveBeenCalled();
   });
 
+  it('should allow new-file writes matching a template-level exclude glob from scaffold.yaml', async (): Promise<void> => {
+    // Path is not covered by the global excludeGlobs, but the template's scaffold.yaml
+    // exclude list (surfaced on the methods result) covers it — so it is allowed.
+    mockExecute.mockResolvedValue(
+      makeMethodsResult(
+        [{ name: 'scaffold-route', description: 'Generate a new route' }],
+        undefined,
+        ['**/*.gen.ts'],
+      ),
+    );
+
+    const result = await hook.preToolUse(
+      makePreToolUseContext({
+        tool_input: { file_path: '/test/apps/my-app/src/schema.gen.ts' },
+      }),
+    );
+
+    expect(result.decision).toBe(DECISION_ALLOW);
+    expect(result.message).toContain('template');
+    // Template excludes come from the methods result, so the tool IS consulted.
+    expect(mockExecute).toHaveBeenCalled();
+  });
+
   it('should still deny new-file writes to scaffoldable source paths when methods exist', async (): Promise<void> => {
-    mockExecute.mockResolvedValue(makeMethodsResult([{ name: 'scaffold-route', description: 'Generate a new route' }]));
+    mockExecute.mockResolvedValue(
+      makeMethodsResult([{ name: 'scaffold-route', description: 'Generate a new route' }]),
+    );
 
     const result = await hook.preToolUse(
       makePreToolUseContext({
@@ -247,8 +287,27 @@ describe('UseScaffoldMethodHook.preToolUse', (): void => {
     expect(result.message).toContain('- **scaffold-route**: Generate a new route');
   });
 
+  it('should deny content writes when no excludeGlobs are configured', async (): Promise<void> => {
+    // Without configured excludeGlobs the broad enforcement stays intact.
+    vi.mocked(TemplatesManagerService.readToolkitConfig).mockResolvedValueOnce(null);
+    mockExecute.mockResolvedValue(
+      makeMethodsResult([{ name: 'scaffold-route', description: 'Generate a new route' }]),
+    );
+
+    const result = await hook.preToolUse(
+      makePreToolUseContext({
+        tool_input: { file_path: '/test/apps/my-app/src/content/blog/x.mdx' },
+      }),
+    );
+
+    expect(result.decision).toBe(DECISION_DENY);
+    expect(result.message).toContain('- **scaffold-route**: Generate a new route');
+  });
+
   it('should not include instruction text or required variables in the message', async (): Promise<void> => {
-    mockExecute.mockResolvedValue(makeMethodsResult([{ name: 'scaffold-route', description: 'Short description' }]));
+    mockExecute.mockResolvedValue(
+      makeMethodsResult([{ name: 'scaffold-route', description: 'Short description' }]),
+    );
 
     const result = await hook.preToolUse(makePreToolUseContext());
 

--- a/packages/scaffold-mcp/tests/hooks/claudeCode/useScaffoldMethod.test.ts
+++ b/packages/scaffold-mcp/tests/hooks/claudeCode/useScaffoldMethod.test.ts
@@ -64,9 +64,7 @@ const { mockExecute, mockHasExecuted, mockLogExecution, mockLoadLog } = vi.hoist
 
 vi.mock(
   '@agiflowai/hooks-adapter',
-  async (
-    importOriginal: () => Promise<typeof import('@agiflowai/hooks-adapter')>,
-  ): Promise<object> => {
+  async (importOriginal: () => Promise<typeof import('@agiflowai/hooks-adapter')>): Promise<object> => {
     const actual = await importOriginal<typeof import('@agiflowai/hooks-adapter')>();
     return {
       ...actual,
@@ -116,9 +114,7 @@ vi.mock('node:fs/promises', (): object => ({
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makePreToolUseContext(
-  overrides: Partial<ClaudeCodePreToolUseInput> = {},
-): ClaudeCodePreToolUseInput {
+function makePreToolUseContext(overrides: Partial<ClaudeCodePreToolUseInput> = {}): ClaudeCodePreToolUseInput {
   return {
     hook_event_name: 'PreToolUse',
     tool_name: 'Write',
@@ -183,9 +179,7 @@ describe('UseScaffoldMethodHook.preToolUse', (): void => {
   });
 
   it('should skip files outside the cwd', async (): Promise<void> => {
-    const result = await hook.preToolUse(
-      makePreToolUseContext({ tool_input: { file_path: '/other/path/file.ts' } }),
-    );
+    const result = await hook.preToolUse(makePreToolUseContext({ tool_input: { file_path: '/other/path/file.ts' } }));
     expect(result.decision).toBe(DECISION_SKIP);
   });
 
@@ -225,10 +219,36 @@ describe('UseScaffoldMethodHook.preToolUse', (): void => {
     expect(result.message).toContain('- **scaffold-component**: Generate a new React component');
   });
 
-  it('should not include instruction text or required variables in the message', async (): Promise<void> => {
-    mockExecute.mockResolvedValue(
-      makeMethodsResult([{ name: 'scaffold-route', description: 'Short description' }]),
+  it('should allow new-file writes to non-scaffoldable content paths even when methods exist', async (): Promise<void> => {
+    mockExecute.mockResolvedValue(makeMethodsResult([{ name: 'scaffold-route', description: 'Generate a new route' }]));
+
+    const result = await hook.preToolUse(
+      makePreToolUseContext({
+        tool_input: { file_path: '/test/apps/my-app/src/content/blog/x.mdx' },
+      }),
     );
+
+    expect(result.decision).toBe(DECISION_ALLOW);
+    expect(result.message).toContain('non-scaffoldable');
+    // Content files short-circuit before scaffold methods are ever consulted.
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it('should still deny new-file writes to scaffoldable source paths when methods exist', async (): Promise<void> => {
+    mockExecute.mockResolvedValue(makeMethodsResult([{ name: 'scaffold-route', description: 'Generate a new route' }]));
+
+    const result = await hook.preToolUse(
+      makePreToolUseContext({
+        tool_input: { file_path: '/test/apps/my-app/src/api/x.ts' },
+      }),
+    );
+
+    expect(result.decision).toBe(DECISION_DENY);
+    expect(result.message).toContain('- **scaffold-route**: Generate a new route');
+  });
+
+  it('should not include instruction text or required variables in the message', async (): Promise<void> => {
+    mockExecute.mockResolvedValue(makeMethodsResult([{ name: 'scaffold-route', description: 'Short description' }]));
 
     const result = await hook.preToolUse(makePreToolUseContext());
 

--- a/packages/scaffold-mcp/tests/hooks/geminiCli/useScaffoldMethod.test.ts
+++ b/packages/scaffold-mcp/tests/hooks/geminiCli/useScaffoldMethod.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { DECISION_DENY, DECISION_SKIP } from '@agiflowai/hooks-adapter';
+import { DECISION_ALLOW, DECISION_DENY, DECISION_SKIP } from '@agiflowai/hooks-adapter';
 import fs from 'node:fs/promises';
 
 const mockExecute = vi.fn();
@@ -131,5 +131,47 @@ describe('Gemini UseScaffoldMethodHook.preToolUse', () => {
     const result = await hook.preToolUse(makeContext());
     expect(result.decision).toBe(DECISION_DENY);
     expect(result.message).toContain('No scaffolding methods are available');
+  });
+
+  it('allows new-file writes to non-scaffoldable content paths even when methods exist', async () => {
+    mockExecute.mockResolvedValue({
+      isError: false,
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            methods: [{ name: 'scaffold-route', description: 'Generate a new route' }],
+          }),
+        },
+      ],
+    });
+
+    const result = await hook.preToolUse(
+      makeContext({ tool_input: { file_path: '/test/apps/my-app/src/content/blog/x.mdx' } }),
+    );
+
+    expect(result.decision).toBe(DECISION_ALLOW);
+    expect(result.message).toContain('non-scaffoldable');
+    // Content files short-circuit before scaffold methods are ever consulted.
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it('still denies new-file writes to scaffoldable source paths when methods exist', async () => {
+    mockExecute.mockResolvedValue({
+      isError: false,
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            methods: [{ name: 'scaffold-route', description: 'Generate a new route' }],
+          }),
+        },
+      ],
+    });
+
+    const result = await hook.preToolUse(makeContext({ tool_input: { file_path: '/test/apps/my-app/src/api/x.ts' } }));
+
+    expect(result.decision).toBe(DECISION_DENY);
+    expect(result.message).toContain('- **scaffold-route**: Generate a new route');
   });
 });

--- a/packages/scaffold-mcp/tests/hooks/geminiCli/useScaffoldMethod.test.ts
+++ b/packages/scaffold-mcp/tests/hooks/geminiCli/useScaffoldMethod.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { DECISION_ALLOW, DECISION_DENY, DECISION_SKIP } from '@agiflowai/hooks-adapter';
+import { TemplatesManagerService } from '@agiflowai/aicode-utils';
 import fs from 'node:fs/promises';
 
 const mockExecute = vi.fn();
@@ -24,6 +25,9 @@ vi.mock('@agiflowai/aicode-utils', () => ({
   TemplatesManagerService: {
     findTemplatesPath: vi.fn().mockResolvedValue('/test/templates'),
     getWorkspaceRoot: vi.fn().mockResolvedValue('/test'),
+    readToolkitConfig: vi.fn().mockResolvedValue({
+      'scaffold-mcp': { hook: { excludeGlobs: ['**/*.md', '**/*.mdx', '**/src/content/**'] } },
+    }),
   },
   ProjectFinderService: vi.fn(function MockProjectFinderService() {
     return {
@@ -133,7 +137,7 @@ describe('Gemini UseScaffoldMethodHook.preToolUse', () => {
     expect(result.message).toContain('No scaffolding methods are available');
   });
 
-  it('allows new-file writes to non-scaffoldable content paths even when methods exist', async () => {
+  it('allows new-file writes matching configured global excludeGlobs even when methods exist', async () => {
     mockExecute.mockResolvedValue({
       isError: false,
       content: [
@@ -151,8 +155,8 @@ describe('Gemini UseScaffoldMethodHook.preToolUse', () => {
     );
 
     expect(result.decision).toBe(DECISION_ALLOW);
-    expect(result.message).toContain('non-scaffoldable');
-    // Content files short-circuit before scaffold methods are ever consulted.
+    expect(result.message).toContain('excludeGlobs');
+    // Global excludeGlobs short-circuit before scaffold methods are ever consulted.
     expect(mockExecute).not.toHaveBeenCalled();
   });
 
@@ -169,7 +173,58 @@ describe('Gemini UseScaffoldMethodHook.preToolUse', () => {
       ],
     });
 
-    const result = await hook.preToolUse(makeContext({ tool_input: { file_path: '/test/apps/my-app/src/api/x.ts' } }));
+    const result = await hook.preToolUse(
+      makeContext({ tool_input: { file_path: '/test/apps/my-app/src/api/x.ts' } }),
+    );
+
+    expect(result.decision).toBe(DECISION_DENY);
+    expect(result.message).toContain('- **scaffold-route**: Generate a new route');
+  });
+
+  it('allows new-file writes matching a template-level exclude glob from scaffold.yaml', async () => {
+    // Path is not covered by the global excludeGlobs, but the template's scaffold.yaml
+    // exclude list (surfaced on the methods result) covers it — so it is allowed.
+    mockExecute.mockResolvedValue({
+      isError: false,
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            methods: [{ name: 'scaffold-route', description: 'Generate a new route' }],
+            excludeGlobs: ['**/*.gen.ts'],
+          }),
+        },
+      ],
+    });
+
+    const result = await hook.preToolUse(
+      makeContext({ tool_input: { file_path: '/test/apps/my-app/src/schema.gen.ts' } }),
+    );
+
+    expect(result.decision).toBe(DECISION_ALLOW);
+    expect(result.message).toContain('template');
+    // Template excludes come from the methods result, so the tool IS consulted.
+    expect(mockExecute).toHaveBeenCalled();
+  });
+
+  it('denies content writes when no excludeGlobs are configured', async () => {
+    // Without configured excludeGlobs the broad enforcement stays intact.
+    vi.mocked(TemplatesManagerService.readToolkitConfig).mockResolvedValueOnce(null);
+    mockExecute.mockResolvedValue({
+      isError: false,
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            methods: [{ name: 'scaffold-route', description: 'Generate a new route' }],
+          }),
+        },
+      ],
+    });
+
+    const result = await hook.preToolUse(
+      makeContext({ tool_input: { file_path: '/test/apps/my-app/src/content/blog/x.mdx' } }),
+    );
 
     expect(result.decision).toBe(DECISION_DENY);
     expect(result.message).toContain('- **scaffold-route**: Generate a new route');


### PR DESCRIPTION
## Summary

Makes the scaffold-mcp PreToolUse hook's enforcement relaxation **configurable** instead of relying on a hardcoded allow-list.

Once a template defines scaffolding methods, the hook denies new-file `Write`s that don't go through a scaffolding method (to enforce structure). Some files are never scaffolded — docs, content collections, generated code — and denying them pushes agents to bypass the hook entirely (e.g. Bash heredocs), which also skips downstream review hooks. This PR replaces the hardcoded `NON_SCAFFOLDABLE_GLOBS` list with two configurable exclude-glob levers.

## The two levers

- **Workspace-wide** — `scaffold-mcp.hook.excludeGlobs` in `.toolkit/settings.yaml` (applies to every agent/project). Ships the previous `**/*.md`, `**/*.mdx`, `**/src/content/**` defaults so behavior is preserved out of the box. Loaded via `TemplatesManagerService.readToolkitConfig` and **fails open** (a missing/broken config never blocks writes).
- **Per-template** — a top-level `exclude:` list in a template's `scaffold.yaml` (applies only to projects scaffolded from that template). Surfaced through `list-scaffolding-methods` (`ListScaffoldingMethodsResult.excludeGlobs`) and validated in the zod schema.

A new-file write is **allowed through** when its absolute path matches a glob in **either** list (minimatch, `**` prefixes, `{ dot: true }`); the lists are additive. Otherwise a template with scaffold methods still denies with guidance — enforcement stays intact when nothing is configured.

## Changes

- `aicode-utils`: add `excludeGlobs?: string[]` to `HookConfig`.
- `scaffold-mcp/hooks/shared.ts`: new `matchesExcludeGlob` + `getGlobalExcludeGlobs` helpers (replace the hardcoded list/`isNonScaffoldableTarget`).
- Both Claude Code & Gemini hooks: global-exclude check before method lookup; template-exclude check before the deny.
- `ScaffoldConfigLoader`: validate the new top-level `exclude` key.
- `ScaffoldingMethodsService`: thread `excludeGlobs` onto the result (auto-surfaced in the tool's JSON).
- `commands/hook.ts`: narrow a `HookConfig` index cast to exclude the new non-agent key.
- `.toolkit/settings.yaml`: ship the default `excludeGlobs`.
- Docs: new "Relaxing Enforcement" section in `hooks.md`, an `exclude` subsection in `template-conventions.md`, and a README note.

## Test plan

- New unit tests on both hooks: global-exclude allow (tool never consulted), template-exclude allow (tool consulted), scaffoldable path still denies, and **deny when no excludeGlobs are configured** (proves enforcement is config-driven, not hardcoded).
- `pnpm build`, `pnpm lint`, `pnpm typecheck`, `pnpm test` — all green across the monorepo (scaffold-mcp 275/275).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
