### PR TITLE
feat(scaffold-mcp): add Codex CLI scaffold hook

### DIFF
--- a/.toolkit/settings.yaml
+++ b/.toolkit/settings.yaml
@@ -26,6 +26,8 @@ scaffold-mcp:
       - '**/*.md'
       - '**/*.mdx'
       - '**/src/content/**'
+      - '**/*.test.ts'
+      - '**/*.spec.ts'
 
     claude-code:
       preToolUse:

--- a/packages/aicode-utils/src/types/index.ts
+++ b/packages/aicode-utils/src/types/index.ts
@@ -109,6 +109,8 @@ export interface HookConfig {
   'claude-code'?: HookAgentConfig;
   /** Hook config for Gemini CLI agent. */
   'gemini-cli'?: HookAgentConfig;
+  /** Hook config for OpenAI Codex CLI agent. */
+  codex?: HookAgentConfig;
 }
 
 /**

--- a/packages/hooks-adapter/src/adapters/CodexAdapter.ts
+++ b/packages/hooks-adapter/src/adapters/CodexAdapter.ts
@@ -1,0 +1,37 @@
+/**
+ * CodexAdapter - Adapter for OpenAI Codex CLI hook format
+ *
+ * DESIGN PATTERNS:
+ * - Adapter pattern: Converts Codex CLI hook format to normalized format
+ * - Reuse over duplication: Codex's hook wire contract matches Claude Code's, so
+ *   this extends ClaudeCodeAdapter rather than re-implementing the same I/O
+ *
+ * WHY THIS MIRRORS CLAUDE CODE:
+ * Codex CLI's hook system uses the same event names (PreToolUse, PostToolUse,
+ * Stop, UserPromptSubmit), the same stdin fields (cwd, session_id, tool_name,
+ * tool_input, tool_use_id, permission_mode, hook_event_name), and the same stdout
+ * shape (`hookSpecificOutput.permissionDecision: 'allow' | 'deny' | 'ask'`).
+ * The differences are payload-level, not wire-level: Codex adds turn_id/model and
+ * creates files via the `apply_patch` tool (the patch lives in tool_input.command),
+ * which the scaffold-mcp hook handles — not this adapter.
+ *
+ * AVOID:
+ * - Re-implementing parsing/formatting that ClaudeCodeAdapter already provides
+ */
+
+import { ClaudeCodeAdapter } from './ClaudeCodeAdapter';
+import type { ClaudeCodeHookInput } from './ClaudeCodeAdapter';
+
+/**
+ * Codex CLI hook input. Structurally identical to the Claude Code hook input on the
+ * wire (Codex additionally sends `turn_id`/`model`, which the scaffold hook does not
+ * read), so it reuses {@link ClaudeCodeHookInput}.
+ */
+export type CodexHookInput = ClaudeCodeHookInput;
+
+/**
+ * Adapter for OpenAI Codex CLI hooks. Codex's hook stdin/stdout contract matches
+ * Claude Code's, so parsing and response formatting are inherited verbatim from
+ * {@link ClaudeCodeAdapter}.
+ */
+export class CodexAdapter extends ClaudeCodeAdapter {}

--- a/packages/hooks-adapter/src/adapters/index.ts
+++ b/packages/hooks-adapter/src/adapters/index.ts
@@ -18,6 +18,7 @@
 export { BaseAdapter } from './BaseAdapter';
 export { ClaudeCodeAdapter } from './ClaudeCodeAdapter';
 export { GeminiCliAdapter } from './GeminiCliAdapter';
+export { CodexAdapter } from './CodexAdapter';
 
 // Export adapter-specific types
 export type { ClaudeCodePreToolUseInput } from './ClaudeCodeAdapter';
@@ -27,3 +28,4 @@ export type { ClaudeCodeUserPromptSubmitInput } from './ClaudeCodeAdapter';
 export type { ClaudeCodeTaskCompletedInput } from './ClaudeCodeAdapter';
 export type { ClaudeCodeHookInput } from './ClaudeCodeAdapter';
 export type { GeminiCliHookInput } from './GeminiCliAdapter';
+export type { CodexHookInput } from './CodexAdapter';

--- a/packages/scaffold-mcp/README.md
+++ b/packages/scaffold-mcp/README.md
@@ -303,6 +303,8 @@ Hooks let scaffold-mcp proactively suggest templates when your AI agent creates 
 
 When Claude tries to write a new file, the hook shows available scaffolding methods that match, so Claude can use templates instead of writing from scratch.
 
+Hooks are also available for **Gemini CLI** and **OpenAI Codex CLI** (`--type codex.preToolUse`, configured in `.codex/config.toml`); see the hooks docs for setup.
+
 **Relaxing enforcement:** to let some files (docs, content, generated code) be written directly, add exclude globs — workspace-wide via `scaffold-mcp.hook.excludeGlobs` in `.toolkit/settings.yaml`, or per-template via a top-level `exclude` in `scaffold.yaml`:
 
 ```yaml

--- a/packages/scaffold-mcp/docs/hooks.md
+++ b/packages/scaffold-mcp/docs/hooks.md
@@ -125,6 +125,42 @@ Add to `~/.gemini/settings.json`:
 
 ---
 
+## Codex CLI Setup
+
+Codex CLI ships a hook system modeled on Claude Code's — the same `PreToolUse`/`PostToolUse`
+events and the same `permissionDecision` response — so scaffold-mcp reuses that wire format.
+Configure hooks in `~/.codex/config.toml` (or a project-level `.codex/config.toml`):
+
+```toml
+[[hooks.PreToolUse]]
+# Codex creates files via the apply_patch tool — scope the hook to it.
+matcher = "^apply_patch$"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "npx @agiflowai/scaffold-mcp hook --type codex.preToolUse"
+
+[[hooks.PostToolUse]]
+matcher = "^apply_patch$"
+
+[[hooks.PostToolUse.hooks]]
+type = "command"
+command = "npx @agiflowai/scaffold-mcp hook --type codex.postToolUse"
+```
+
+### What Happens
+
+Codex creates new files through the `apply_patch` tool, whose patch body contains
+`*** Add File: <path>` blocks. The PreToolUse hook parses those blocks to find the new
+files, then — like the Claude Code hook — suggests matching scaffolding methods, unless
+the path is covered by an [exclude glob](#relaxing-enforcement). The
+`permissionDecision: deny` Codex returns surfaces the guidance; Codex can still proceed
+if no scaffold method fits.
+
+Existing-file edits (`*** Update File:`) and shell writes (`Bash`) are not intercepted.
+
+---
+
 ## Hook Decisions
 
 | Decision | Claude Code | Gemini CLI | Behavior |
@@ -134,7 +170,7 @@ Add to `~/.gemini/settings.json`:
 | Skip | `skip` | - | Silently allow (no output) |
 | Warn | - | `WARN` | Show warning but allow |
 
-**Note:** The PreToolUse hook uses `deny` to show scaffolding options. This displays the message to Claude but doesn't actually block the Write operation—Claude can still proceed if no scaffold methods are relevant.
+**Note:** The PreToolUse hook uses `deny` to show scaffolding options. This displays the message to Claude but doesn't actually block the Write operation—Claude can still proceed if no scaffold methods are relevant. Codex CLI uses the same decision contract as Claude Code (`hookSpecificOutput.permissionDecision: allow | deny | ask`).
 
 ---
 
@@ -195,6 +231,10 @@ npx @agiflowai/scaffold-mcp hook --type claude-code.postToolUse
 # Gemini CLI hooks (WIP)
 npx @agiflowai/scaffold-mcp hook --type gemini-cli.beforeToolUse
 npx @agiflowai/scaffold-mcp hook --type gemini-cli.afterToolUse
+
+# Codex CLI hooks
+npx @agiflowai/scaffold-mcp hook --type codex.preToolUse
+npx @agiflowai/scaffold-mcp hook --type codex.postToolUse
 ```
 
 Hook commands read tool context from stdin and write responses to stdout (JSON format).

--- a/packages/scaffold-mcp/src/commands/hook.ts
+++ b/packages/scaffold-mcp/src/commands/hook.ts
@@ -23,6 +23,7 @@
 import {
   CLAUDE_CODE,
   GEMINI_CLI,
+  CODEX,
   SUPPORTED_LLM_TOOLS,
   isValidLlmTool,
 } from '@agiflowai/coding-agent-bridge';
@@ -30,9 +31,11 @@ import type { HookAgentConfig, HookConfig } from '@agiflowai/aicode-utils';
 import {
   ClaudeCodeAdapter,
   GeminiCliAdapter,
+  CodexAdapter,
   parseHookType,
   type ClaudeCodeHookInput,
   type GeminiCliHookInput,
+  type CodexHookInput,
   type HookResponse,
 } from '@agiflowai/hooks-adapter';
 import { TemplatesManagerService, print } from '@agiflowai/aicode-utils';
@@ -68,6 +71,9 @@ type ClaudeCodeHookCallback = (context: ClaudeCodeHookInput) => Promise<HookResp
 /** Type for Gemini CLI hook callback function */
 type GeminiCliHookCallback = (context: GeminiCliHookInput) => Promise<HookResponse>;
 
+/** Type for Codex CLI hook callback function */
+type CodexHookCallback = (context: CodexHookInput) => Promise<HookResponse>;
+
 /** Interface for class-based hook with lifecycle methods */
 interface HookClass<T> {
   preToolUse?: (context: T) => Promise<HookResponse>;
@@ -86,6 +92,11 @@ interface ClaudeCodeHookModule {
 /** Interface for Gemini CLI hook module exports */
 interface GeminiCliHookModule {
   UseScaffoldMethodHook?: new () => HookClass<GeminiCliHookInput>;
+}
+
+/** Interface for Codex CLI hook module exports */
+interface CodexHookModule {
+  UseScaffoldMethodHook?: new () => HookClass<CodexHookInput>;
 }
 
 /** Type guard for valid scaffold hook method keys */
@@ -258,8 +269,31 @@ export const hookCommand = new Command('hook')
 
         const adapter = new GeminiCliAdapter();
         await adapter.executeMultiple(geminiCallbacks, resolvedAdapterConfig);
+      } else if (agent === CODEX) {
+        // Import hook module via barrel export (dynamic for conditional loading based on agent type)
+        const hookModule: CodexHookModule = await import('../hooks/codex');
+
+        const codexCallbacks: CodexHookCallback[] = [];
+
+        if (hookModule.UseScaffoldMethodHook) {
+          const hookInstance = new hookModule.UseScaffoldMethodHook();
+          const hookFn = hookInstance[hookMethod];
+          if (hookFn) {
+            codexCallbacks.push(hookFn.bind(hookInstance));
+          }
+        }
+
+        if (codexCallbacks.length === 0) {
+          // No hooks registered for this method — exit gracefully (no-op)
+          process.exit(0);
+        }
+
+        const adapter = new CodexAdapter();
+        await adapter.executeMultiple(codexCallbacks, resolvedAdapterConfig);
       } else {
-        throw new Error(`Unsupported agent: ${agent}. Supported: ${CLAUDE_CODE}, ${GEMINI_CLI}`);
+        throw new Error(
+          `Unsupported agent: ${agent}. Supported: ${CLAUDE_CODE}, ${GEMINI_CLI}, ${CODEX}`,
+        );
       }
     } catch (error) {
       print.error(`Hook error: ${error instanceof Error ? error.message : String(error)}`);

--- a/packages/scaffold-mcp/src/hooks/codex/index.ts
+++ b/packages/scaffold-mcp/src/hooks/codex/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Scaffold Codex CLI Hooks Barrel Exports
+ */
+
+export { UseScaffoldMethodHook } from './useScaffoldMethod';

--- a/packages/scaffold-mcp/src/hooks/codex/useScaffoldMethod.ts
+++ b/packages/scaffold-mcp/src/hooks/codex/useScaffoldMethod.ts
@@ -1,0 +1,427 @@
+/**
+ * UseScaffoldMethod Hook for OpenAI Codex CLI
+ *
+ * DESIGN PATTERNS:
+ * - Class-based hook pattern: Encapsulates lifecycle hooks in a single class
+ * - Fail-open pattern: Errors allow operation to proceed with warning
+ * - Proactive guidance: Shows available scaffolding methods before tool execution
+ *
+ * CODEX SPECIFICS:
+ * Codex's hook wire format matches Claude Code's (see CodexAdapter), so the
+ * input/output handling is shared. The one difference is the file-write tool:
+ * Codex creates files via `apply_patch`, whose `tool_input.command` is a patch
+ * body containing `*** Add File: <path>` blocks — there is no `tool_input.file_path`.
+ * New-file targets are therefore parsed from the patch (see resolveApplyPatchNewFileTargets).
+ *
+ * AVOID:
+ * - Blocking operations on errors
+ * - Complex business logic (delegate to tools/services)
+ * - Mutating context object
+ */
+
+import type {
+  CodexHookInput,
+  HookResponse,
+  ScaffoldExecution,
+  LogEntry,
+} from '@agiflowai/hooks-adapter';
+import {
+  ExecutionLogService,
+  DECISION_SKIP,
+  DECISION_DENY,
+  DECISION_ALLOW,
+} from '@agiflowai/hooks-adapter';
+import { ListScaffoldingMethodsTool } from '../../tools/ListScaffoldingMethodsTool';
+import { TemplatesManagerService, ProjectFinderService } from '@agiflowai/aicode-utils';
+import path from 'node:path';
+import {
+  formatScaffoldMethodsHookMessage,
+  matchesExcludeGlob,
+  getGlobalExcludeGlobs,
+  resolveApplyPatchNewFileTargets,
+  resolveApplyPatchEditedPaths,
+} from '../shared';
+
+/**
+ * Scaffold method definition from the list-scaffolding-methods tool
+ */
+interface ScaffoldMethod {
+  name: string;
+  description?: string;
+}
+
+/**
+ * Response from the list-scaffolding-methods tool
+ */
+interface ScaffoldMethodsResponse {
+  methods?: ScaffoldMethod[];
+  /** Template-level exclude globs from scaffold.yaml (see {@link matchesExcludeGlob}). */
+  excludeGlobs?: string[];
+  nextCursor?: string;
+}
+
+/**
+ * Extended ExecutionLogService interface with loadLog method
+ */
+interface ExecutionLogServiceWithLoadLog extends ExecutionLogService {
+  loadLog(): Promise<LogEntry[]>;
+}
+
+/**
+ * Type guard for ScaffoldMethodsResponse
+ */
+function isScaffoldMethodsResponse(value: unknown): value is ScaffoldMethodsResponse {
+  if (typeof value !== 'object' || value === null) return false;
+  if ('methods' in value && !Array.isArray(value.methods)) return false;
+  if ('excludeGlobs' in value && !Array.isArray(value.excludeGlobs)) return false;
+  if ('nextCursor' in value && typeof value.nextCursor !== 'string') return false;
+  return true;
+}
+
+/**
+ * UseScaffoldMethod Hook class for Codex CLI
+ *
+ * Provides lifecycle hooks for tool execution:
+ * - preToolUse: Shows available scaffolding methods before an apply_patch creates new files
+ * - postToolUse: Tracks scaffold completion progress after file edits
+ */
+export class UseScaffoldMethodHook {
+  /**
+   * PreToolUse hook for Codex CLI
+   * Proactively shows available scaffolding methods and guides the agent to use them
+   * when an apply_patch is about to create a new file.
+   *
+   * @param context - Codex CLI hook input
+   * @returns Hook response with scaffolding methods guidance
+   */
+  async preToolUse(context: CodexHookInput): Promise<HookResponse> {
+    try {
+      // Guard: only tool-use events carry tool_name and tool_input
+      if (!('tool_name' in context)) {
+        return { decision: DECISION_SKIP, message: 'Not a tool use event' };
+      }
+
+      // Codex creates files via apply_patch; the patch body lives in tool_input.command.
+      const command =
+        typeof context.tool_input?.command === 'string' ? context.tool_input.command : undefined;
+      const newFileTargets = resolveApplyPatchNewFileTargets(
+        context.cwd,
+        context.tool_name,
+        command,
+      );
+      if (newFileTargets.length === 0) {
+        return {
+          decision: DECISION_SKIP,
+          message: 'Not a new-file apply_patch operation',
+        };
+      }
+
+      // Workspace-wide excludeGlobs bypass scaffold enforcement. Enforce on the first
+      // new file not covered by them; if every new file is excluded, allow directly.
+      const globalExcludeGlobs = await getGlobalExcludeGlobs(context.cwd);
+      const target = newFileTargets.find((p) => !matchesExcludeGlob(p, globalExcludeGlobs));
+      if (!target) {
+        return {
+          decision: DECISION_ALLOW,
+          message: 'New file(s) match configured excludeGlobs - writing directly.',
+        };
+      }
+
+      // Only prompt once per new-file target per session
+      const executionLog = new ExecutionLogService(context.session_id);
+      const alreadyShown = await executionLog.hasExecuted({
+        filePath: target,
+        decision: DECISION_DENY,
+      });
+      if (alreadyShown) {
+        return {
+          decision: DECISION_SKIP,
+          message: 'Scaffolding methods already provided for this file',
+        };
+      }
+
+      const templatesPath = await TemplatesManagerService.findTemplatesPath();
+      if (!templatesPath) {
+        return {
+          decision: DECISION_SKIP,
+          message: 'Templates folder not found - skipping scaffold method check',
+        };
+      }
+      const tool = new ListScaffoldingMethodsTool(templatesPath, false);
+
+      // Derive project path from the new file by finding the nearest project.json
+      const workspaceRoot = await TemplatesManagerService.getWorkspaceRoot(context.cwd);
+      const projectFinder = new ProjectFinderService(workspaceRoot);
+      const projectConfig = await projectFinder.findProjectForFile(target);
+      const projectPath = projectConfig?.root || context.cwd;
+
+      const result = await tool.execute({ projectPath });
+
+      const firstContent = result.content[0];
+      if (firstContent?.type !== 'text') {
+        return {
+          decision: DECISION_SKIP,
+          message: '⚠️ Unexpected response type from scaffolding methods tool',
+        };
+      }
+      if (result.isError) {
+        return {
+          decision: DECISION_SKIP,
+          message: `⚠️ Could not load scaffolding methods: ${firstContent.text}`,
+        };
+      }
+
+      const resultText = firstContent.text;
+      if (typeof resultText !== 'string') {
+        return {
+          decision: DECISION_SKIP,
+          message: '⚠️ Invalid response format from scaffolding methods tool',
+        };
+      }
+
+      const parsed: unknown = JSON.parse(resultText);
+      if (!isScaffoldMethodsResponse(parsed)) {
+        return {
+          decision: DECISION_SKIP,
+          message: '⚠️ Unexpected response shape from scaffolding methods tool',
+        };
+      }
+      const data = parsed;
+
+      // Per-template relaxation: writes matching the template's scaffold.yaml `exclude`
+      // globs bypass enforcement even when scaffold methods exist.
+      if (matchesExcludeGlob(target, data.excludeGlobs)) {
+        return {
+          decision: DECISION_ALLOW,
+          message: 'File matches template exclude globs - writing directly.',
+        };
+      }
+
+      if (!data.methods || data.methods.length === 0) {
+        await executionLog.logExecution({
+          filePath: target,
+          operation: 'list-scaffold-methods',
+          decision: DECISION_ALLOW,
+        });
+        return {
+          decision: DECISION_ALLOW,
+          message:
+            'No scaffolding methods are available for this project template. You should write new files directly.',
+        };
+      }
+
+      const message = formatScaffoldMethodsHookMessage(data.methods);
+
+      // Log that we showed methods for this file (decision: deny)
+      await executionLog.logExecution({
+        filePath: target,
+        operation: 'list-scaffold-methods',
+        decision: DECISION_DENY,
+      });
+
+      // Return DENY to surface guidance to Codex (does not hard-block apply_patch)
+      return {
+        decision: DECISION_DENY,
+        message,
+      };
+    } catch (error) {
+      // Fail open: skip hook and let Codex continue
+      return {
+        decision: DECISION_SKIP,
+        message: `⚠️ Hook error: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+  }
+
+  /**
+   * PostToolUse hook for Codex CLI
+   * Tracks file edits after scaffold generation and reminds the agent to complete
+   * the implementation of all scaffold-generated files.
+   *
+   * @param context - Codex CLI hook input
+   * @returns Hook response with scaffold completion tracking
+   */
+  async postToolUse(context: CodexHookInput): Promise<HookResponse> {
+    try {
+      if (!('tool_name' in context)) {
+        return { decision: DECISION_SKIP, message: 'Not a tool use event' };
+      }
+
+      const executionLog = new ExecutionLogService(context.session_id);
+
+      // A use-scaffold-method execution logs its generated files via the tool itself;
+      // just acknowledge it here so progress tracking can pick it up later.
+      if (
+        context.tool_name === 'use-scaffold-method' ||
+        context.tool_input?.toolName === 'use-scaffold-method'
+      ) {
+        return {
+          decision: DECISION_ALLOW,
+          message: 'Scaffold execution logged for progress tracking',
+        };
+      }
+
+      const command =
+        typeof context.tool_input?.command === 'string' ? context.tool_input.command : undefined;
+      const editedPaths = resolveApplyPatchEditedPaths(context.tool_name, command);
+      if (editedPaths.length === 0) {
+        return { decision: DECISION_SKIP, message: 'Not a file edit/write operation' };
+      }
+
+      const lastScaffoldExecution = await getLastScaffoldExecution(
+        executionLog as ExecutionLogServiceWithLoadLog,
+      );
+      if (!lastScaffoldExecution) {
+        return { decision: DECISION_SKIP, message: 'No scaffold execution found' };
+      }
+
+      const { scaffoldId, generatedFiles, featureName } = lastScaffoldExecution;
+
+      const fulfilledKey = `scaffold-fulfilled-${scaffoldId}`;
+      const alreadyFulfilled = await executionLog.hasExecuted({
+        filePath: fulfilledKey,
+        decision: DECISION_ALLOW,
+      });
+      if (alreadyFulfilled) {
+        return { decision: DECISION_SKIP, message: 'Scaffold already fulfilled' };
+      }
+
+      // Track edited paths that belong to the scaffold's generated files. Match both
+      // the raw patch path and its cwd-absolute form (generatedFiles may be either).
+      let touchedScaffoldFile = false;
+      for (const editedPath of editedPaths) {
+        const absoluteEditedPath = path.isAbsolute(editedPath)
+          ? editedPath
+          : path.join(context.cwd, editedPath);
+        const generatedMatch = generatedFiles.find(
+          (f: string) => f === editedPath || f === absoluteEditedPath,
+        );
+        if (!generatedMatch) {
+          continue;
+        }
+        touchedScaffoldFile = true;
+        const editKey = `scaffold-edit-${scaffoldId}-${generatedMatch}`;
+        const alreadyTracked = await executionLog.hasExecuted({
+          filePath: editKey,
+          decision: DECISION_ALLOW,
+        });
+        if (!alreadyTracked) {
+          await executionLog.logExecution({
+            filePath: editKey,
+            operation: 'scaffold-file-edit',
+            decision: DECISION_ALLOW,
+          });
+        }
+      }
+
+      const editedFiles = await getEditedScaffoldFiles(
+        executionLog as ExecutionLogServiceWithLoadLog,
+        scaffoldId,
+      );
+      const totalFiles = generatedFiles.length;
+      const remainingFiles = generatedFiles.filter((f: string) => !editedFiles.includes(f));
+
+      if (remainingFiles.length === 0) {
+        await executionLog.logExecution({
+          filePath: fulfilledKey,
+          operation: 'scaffold-fulfilled',
+          decision: DECISION_ALLOW,
+        });
+        const featureInfo = featureName ? ` for "${featureName}"` : '';
+        return {
+          decision: DECISION_ALLOW,
+          message: `✅ All scaffold files${featureInfo} have been implemented! (${totalFiles}/${totalFiles} files completed)`,
+        };
+      }
+
+      if (touchedScaffoldFile) {
+        const remainingFilesList = remainingFiles.map((f: string) => `  - ${f}`).join('\n');
+        const featureInfo = featureName ? ` for "${featureName}"` : '';
+        const reminderMessage = `
+⚠️ **Scaffold Implementation Progress${featureInfo}: ${editedFiles.length}/${totalFiles} files completed**
+
+**Remaining files to implement:**
+${remainingFilesList}
+
+Don't forget to complete the implementation for all scaffolded files!
+        `.trim();
+        return { decision: DECISION_ALLOW, message: reminderMessage };
+      }
+
+      return {
+        decision: DECISION_SKIP,
+        message: 'Edited file not part of last scaffold execution',
+      };
+    } catch (error) {
+      // Fail open: skip hook and let Codex continue
+      return {
+        decision: DECISION_SKIP,
+        message: `⚠️ Hook error: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+  }
+}
+
+/**
+ * Helper function to get the last scaffold execution for a session.
+ * Returns null if no scaffold execution found or on error.
+ */
+async function getLastScaffoldExecution(
+  executionLog: ExecutionLogServiceWithLoadLog,
+): Promise<ScaffoldExecution | null> {
+  try {
+    const entries = await executionLog.loadLog();
+
+    // Search from end (most recent) for efficiency
+    for (let i = entries.length - 1; i >= 0; i--) {
+      const entry = entries[i];
+
+      if (
+        entry.operation === 'scaffold' &&
+        entry.scaffoldId &&
+        entry.generatedFiles &&
+        entry.generatedFiles.length > 0
+      ) {
+        return {
+          scaffoldId: entry.scaffoldId,
+          generatedFiles: entry.generatedFiles,
+          featureName: entry.featureName,
+        };
+      }
+    }
+
+    return null;
+  } catch (error: unknown) {
+    console.error('Error getting last scaffold execution:', error);
+    return null;
+  }
+}
+
+/**
+ * Helper function to get the list of edited scaffold files.
+ * Returns an empty array if no files found or on error.
+ */
+async function getEditedScaffoldFiles(
+  executionLog: ExecutionLogServiceWithLoadLog,
+  scaffoldId: string,
+): Promise<string[]> {
+  try {
+    const entries = await executionLog.loadLog();
+    const editedFiles: string[] = [];
+
+    for (const entry of entries) {
+      if (
+        entry.operation === 'scaffold-file-edit' &&
+        entry.filePath.startsWith(`scaffold-edit-${scaffoldId}-`)
+      ) {
+        const filePath = entry.filePath.replace(`scaffold-edit-${scaffoldId}-`, '');
+        editedFiles.push(filePath);
+      }
+    }
+
+    return editedFiles;
+  } catch (error: unknown) {
+    console.error(`Error getting edited scaffold files for ${scaffoldId}:`, error);
+    return [];
+  }
+}

--- a/packages/scaffold-mcp/src/hooks/shared.ts
+++ b/packages/scaffold-mcp/src/hooks/shared.ts
@@ -85,6 +85,101 @@ export async function resolveNewFileWriteTarget(
   }
 }
 
+/**
+ * File-path targets extracted from a Codex `apply_patch` command body.
+ */
+export interface ApplyPatchTargets {
+  /** Paths created by `*** Add File:` blocks (new files). */
+  added: string[];
+  /** Paths modified by `*** Update File:` blocks (existing files). */
+  updated: string[];
+  /** Paths removed by `*** Delete File:` blocks. */
+  deleted: string[];
+}
+
+/**
+ * Parses a Codex `apply_patch` command body into the file paths it adds, updates,
+ * and deletes. Paths are returned verbatim (as written in the patch, i.e. relative
+ * to cwd). Pure and synchronous — performs no filesystem access.
+ *
+ * @param command - The `apply_patch` patch body (the tool_input.command string).
+ * @returns The added/updated/deleted path lists.
+ */
+export function parseApplyPatchTargets(command: string): ApplyPatchTargets {
+  const added: string[] = [];
+  const updated: string[] = [];
+  const deleted: string[] = [];
+
+  for (const line of command.split('\n')) {
+    const add = line.match(/^\*\*\* Add File: (.+)$/);
+    if (add) {
+      added.push(add[1].trim());
+      continue;
+    }
+    const update = line.match(/^\*\*\* Update File: (.+)$/);
+    if (update) {
+      updated.push(update[1].trim());
+      continue;
+    }
+    const del = line.match(/^\*\*\* Delete File: (.+)$/);
+    if (del) {
+      deleted.push(del[1].trim());
+    }
+  }
+
+  return { added, updated, deleted };
+}
+
+/**
+ * Resolves the absolute, cwd-scoped paths of NEW files a Codex `apply_patch` tool
+ * call creates (its `*** Add File:` targets). Returns an empty array for any other
+ * tool or a missing command.
+ *
+ * Unlike {@link resolveNewFileWriteTarget} (the Claude/Gemini `Write` resolver), this
+ * performs no on-disk existence check: an `Add File` block is new-file creation by
+ * definition, and the patch fails downstream if the path already exists.
+ *
+ * @param cwd - Working directory the patch paths are relative to.
+ * @param toolName - The Codex tool name (only `apply_patch` is handled).
+ * @param command - The `apply_patch` patch body (tool_input.command).
+ * @returns Absolute paths of new files created under cwd.
+ */
+export function resolveApplyPatchNewFileTargets(
+  cwd: string,
+  toolName: string,
+  command?: string,
+): string[] {
+  if (!command || toolName !== 'apply_patch') {
+    return [];
+  }
+
+  const targets: string[] = [];
+  for (const filePath of parseApplyPatchTargets(command).added) {
+    const absoluteFilePath = path.isAbsolute(filePath) ? filePath : path.join(cwd, filePath);
+    if (absoluteFilePath.startsWith(cwd + path.sep) || absoluteFilePath === cwd) {
+      targets.push(absoluteFilePath);
+    }
+  }
+  return targets;
+}
+
+/**
+ * Returns the file paths a Codex `apply_patch` call writes (adds or updates), as
+ * written in the patch. Used to correlate post-write edits with a scaffold's
+ * generated files. Returns an empty array for any other tool or a missing command.
+ *
+ * @param toolName - The Codex tool name (only `apply_patch` is handled).
+ * @param command - The `apply_patch` patch body (tool_input.command).
+ * @returns The added and updated paths (verbatim).
+ */
+export function resolveApplyPatchEditedPaths(toolName: string, command?: string): string[] {
+  if (!command || toolName !== 'apply_patch') {
+    return [];
+  }
+  const { added, updated } = parseApplyPatchTargets(command);
+  return [...added, ...updated];
+}
+
 export function formatScaffoldMethodsHookMessage(
   methods: ScaffoldMethodSummary[],
   options?: {

--- a/packages/scaffold-mcp/tests/hooks/codex/useScaffoldMethod.test.ts
+++ b/packages/scaffold-mcp/tests/hooks/codex/useScaffoldMethod.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DECISION_ALLOW, DECISION_DENY, DECISION_SKIP } from '@agiflowai/hooks-adapter';
+import { TemplatesManagerService } from '@agiflowai/aicode-utils';
+
+const mockExecute = vi.fn();
+const mockHasExecuted = vi.fn().mockResolvedValue(false);
+const mockLogExecution = vi.fn().mockResolvedValue(undefined);
+const mockFindProjectForFile = vi.fn().mockResolvedValue({ root: '/test/apps/my-app' });
+
+vi.mock('@agiflowai/hooks-adapter', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agiflowai/hooks-adapter')>();
+  return {
+    ...actual,
+    ExecutionLogService: vi.fn(function MockExecutionLogService() {
+      return {
+        hasExecuted: mockHasExecuted,
+        logExecution: mockLogExecution,
+        loadLog: vi.fn().mockResolvedValue([]),
+      };
+    }),
+  };
+});
+
+vi.mock('@agiflowai/aicode-utils', () => ({
+  TemplatesManagerService: {
+    findTemplatesPath: vi.fn().mockResolvedValue('/test/templates'),
+    getWorkspaceRoot: vi.fn().mockResolvedValue('/test'),
+    readToolkitConfig: vi.fn().mockResolvedValue({
+      'scaffold-mcp': { hook: { excludeGlobs: ['**/*.md', '**/*.mdx', '**/src/content/**'] } },
+    }),
+  },
+  ProjectFinderService: vi.fn(function MockProjectFinderService() {
+    return {
+      findProjectForFile: mockFindProjectForFile,
+    };
+  }),
+}));
+
+vi.mock('../../../src/tools/ListScaffoldingMethodsTool', () => ({
+  ListScaffoldingMethodsTool: vi.fn(function MockListScaffoldingMethodsTool() {
+    return { execute: mockExecute };
+  }),
+}));
+
+import { UseScaffoldMethodHook } from '../../../src/hooks/codex';
+
+/** Build an apply_patch command body that adds the given (relative) file paths. */
+function addPatch(...paths: string[]): string {
+  const body = paths.map((p) => `*** Add File: ${p}\n+content`).join('\n');
+  return `*** Begin Patch\n${body}\n*** End Patch`;
+}
+
+function makeContext(overrides: Record<string, unknown> = {}) {
+  return {
+    hook_event_name: 'PreToolUse',
+    tool_name: 'apply_patch',
+    tool_input: { command: addPatch('src/api/x.ts') },
+    cwd: '/test/apps/my-app',
+    session_id: 'codex-session',
+    transcript_path: '',
+    permission_mode: 'default',
+    tool_use_id: 'tu-1',
+    turn_id: 'turn-1',
+    model: 'gpt-5',
+    ...overrides,
+  } as any;
+}
+
+function methodsResult(
+  methods: Array<{ name: string; description?: string }>,
+  excludeGlobs?: string[],
+) {
+  return {
+    isError: false,
+    content: [{ type: 'text', text: JSON.stringify({ methods, excludeGlobs }) }],
+  };
+}
+
+describe('Codex UseScaffoldMethodHook.preToolUse', () => {
+  let hook: UseScaffoldMethodHook;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hook = new UseScaffoldMethodHook();
+    mockHasExecuted.mockResolvedValue(false);
+    mockLogExecution.mockResolvedValue(undefined);
+    mockFindProjectForFile.mockResolvedValue({ root: '/test/apps/my-app' });
+  });
+
+  it('skips non-apply_patch tools', async () => {
+    const result = await hook.preToolUse(
+      makeContext({ tool_name: 'Bash', tool_input: { command: 'echo hi > x.ts' } }),
+    );
+    expect(result.decision).toBe(DECISION_SKIP);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it('skips apply_patch that creates no new files (update only)', async () => {
+    const result = await hook.preToolUse(
+      makeContext({
+        tool_input: {
+          command: '*** Begin Patch\n*** Update File: src/api/x.ts\n+more\n*** End Patch',
+        },
+      }),
+    );
+    expect(result.decision).toBe(DECISION_SKIP);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it('denies a new source file with the available scaffold methods', async () => {
+    mockExecute.mockResolvedValue(
+      methodsResult([{ name: 'scaffold-route', description: 'Generate a new route' }]),
+    );
+
+    const result = await hook.preToolUse(makeContext());
+
+    expect(result.decision).toBe(DECISION_DENY);
+    expect(result.message).toContain('- **scaffold-route**: Generate a new route');
+  });
+
+  it('allows a new file matching configured global excludeGlobs', async () => {
+    mockExecute.mockResolvedValue(
+      methodsResult([{ name: 'scaffold-route', description: 'Generate a new route' }]),
+    );
+
+    const result = await hook.preToolUse(
+      makeContext({ tool_input: { command: addPatch('src/content/blog/x.mdx') } }),
+    );
+
+    expect(result.decision).toBe(DECISION_ALLOW);
+    expect(result.message).toContain('excludeGlobs');
+    // Global excludeGlobs short-circuit before scaffold methods are ever consulted.
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it('allows a new file matching a template-level exclude glob from scaffold.yaml', async () => {
+    mockExecute.mockResolvedValue(
+      methodsResult(
+        [{ name: 'scaffold-route', description: 'Generate a new route' }],
+        ['**/*.gen.ts'],
+      ),
+    );
+
+    const result = await hook.preToolUse(
+      makeContext({ tool_input: { command: addPatch('src/schema.gen.ts') } }),
+    );
+
+    expect(result.decision).toBe(DECISION_ALLOW);
+    expect(result.message).toContain('template');
+    expect(mockExecute).toHaveBeenCalled();
+  });
+
+  it('enforces on the first non-excluded new file in a mixed patch', async () => {
+    mockExecute.mockResolvedValue(
+      methodsResult([{ name: 'scaffold-route', description: 'Generate a new route' }]),
+    );
+
+    // Patch adds an excluded README.md plus a scaffoldable source file.
+    const result = await hook.preToolUse(
+      makeContext({ tool_input: { command: addPatch('README.md', 'src/api/x.ts') } }),
+    );
+
+    expect(result.decision).toBe(DECISION_DENY);
+    expect(result.message).toContain('- **scaffold-route**: Generate a new route');
+  });
+
+  it('denies content writes when no excludeGlobs are configured', async () => {
+    vi.mocked(TemplatesManagerService.readToolkitConfig).mockResolvedValueOnce(null);
+    mockExecute.mockResolvedValue(
+      methodsResult([{ name: 'scaffold-route', description: 'Generate a new route' }]),
+    );
+
+    const result = await hook.preToolUse(
+      makeContext({ tool_input: { command: addPatch('src/content/blog/x.mdx') } }),
+    );
+
+    expect(result.decision).toBe(DECISION_DENY);
+    expect(result.message).toContain('- **scaffold-route**: Generate a new route');
+  });
+
+  it('allows when no scaffold methods are available', async () => {
+    mockExecute.mockResolvedValue(methodsResult([]));
+
+    const result = await hook.preToolUse(makeContext());
+
+    expect(result.decision).toBe(DECISION_ALLOW);
+  });
+
+  it('skips when methods were already shown for this file', async () => {
+    mockHasExecuted.mockResolvedValueOnce(true);
+
+    const result = await hook.preToolUse(makeContext());
+
+    expect(result.decision).toBe(DECISION_SKIP);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds **OpenAI Codex CLI** as a third scaffold-hook agent, alongside Claude Code and Gemini CLI.

> **Stacked on #103** (base branch `feat/scaffold-hook-config`) — the Codex hook reuses the configurable `excludeGlobs` feature from that PR, so this diff shows only the Codex additions. Merge #103 first.

## Key insight

Codex CLI's hook system is modeled on Claude Code's: the same `PreToolUse`/`PostToolUse` events, the same `hookSpecificOutput.permissionDecision: allow | deny | ask` output, and it can block tool calls. The only payload-level difference is that Codex creates files via the **`apply_patch`** tool — a patch string in `tool_input.command` containing `*** Add File: <path>` blocks — instead of a `Write` with `file_path`.

So the wire adapter is reused verbatim and only the new-file detection is Codex-specific.

## Changes

- **hooks-adapter**: `CodexAdapter` extends `ClaudeCodeAdapter` (identical wire format, zero duplication); `CodexHookInput` type.
- **aicode-utils**: `HookConfig` gains a `codex` agent key.
- **scaffold-mcp/hooks/shared.ts**: apply_patch parsers — `parseApplyPatchTargets`, `resolveApplyPatchNewFileTargets`, `resolveApplyPatchEditedPaths`.
- **scaffold-mcp/hooks/codex/**: `UseScaffoldMethodHook` — `preToolUse` (parse apply_patch → new-file detection → global + template `excludeGlobs` → suggest scaffold methods) and `postToolUse` (scaffold completion tracking).
- **scaffold-mcp/commands/hook.ts**: `CODEX` dispatch branch (mirrors Gemini).
- **docs/hooks.md + README.md**: Codex `.codex/config.toml` setup, CLI commands, decision-parity note.
- **.toolkit/settings.yaml**: also excludes `**/*.test.ts` / `**/*.spec.ts` from scaffold enforcement (test files are non-scaffoldable).

## Codex setup

```toml
# ~/.codex/config.toml
[[hooks.PreToolUse]]
matcher = "^apply_patch$"
[[hooks.PreToolUse.hooks]]
type = "command"
command = "npx @agiflowai/scaffold-mcp hook --type codex.preToolUse"
```

## Test plan

- 9 new Codex `preToolUse` unit tests: deny new source file, allow global/template `excludeGlobs`, mixed-patch enforcement, deny-when-unconfigured, no-methods allow, dedup skip, non-apply_patch skip.
- End-to-end smoke test of the real hook CLI against Codex-shaped stdin: new `.ts` → `deny` + method list; new `.md` → `allow` (excludeGlobs); `Bash` → skip.
- `pnpm build`, `pnpm lint`, `pnpm typecheck`, `pnpm test` — all green (scaffold-mcp 284/284).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
